### PR TITLE
fix(overlay): 覆盖层运行时禁止切换窗口模式

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -387,6 +387,13 @@ pub fn run() {
                                 "拒绝切换窗口模式：{}",
                                 tr(locale, "overlay_active_cannot_change_mode")
                             );
+                            // Tauri v2 的 CheckMenuItem 在 on_menu_event 触发前已自动
+                            // 切换勾选状态，guard 早返回时需将其回退到切换前，否则托盘
+                            // 勾选框与实际配置会出现不一致。
+                            let tray_state = app.state::<TrayMenuState>();
+                            let is_window_mode =
+                                tray_state.window_mode_item.is_checked().unwrap_or(false);
+                            let _ = tray_state.window_mode_item.set_checked(!is_window_mode);
                             return;
                         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,12 @@ fn tr(locale: BackendLocale, key: &str) -> String {
     match (locale, key) {
         (BackendLocale::ZhCN, "target_window_required") => "未选择目标窗口".to_string(),
         (BackendLocale::En, "target_window_required") => "No target window selected".to_string(),
+        (BackendLocale::ZhCN, "overlay_active_cannot_change_mode") => {
+            "覆盖层运行中，请先停止覆盖层后再切换模式".to_string()
+        }
+        (BackendLocale::En, "overlay_active_cannot_change_mode") => {
+            "Overlay is active. Stop the overlay before changing the mode.".to_string()
+        }
         (BackendLocale::ZhCN, "png_filter") => "PNG 图片".to_string(),
         (BackendLocale::En, "png_filter") => "PNG images".to_string(),
         (BackendLocale::ZhCN, "tray.config") => "配置".to_string(),
@@ -370,6 +376,20 @@ pub fn run() {
                     }
                     "window_mode" => {
                         // 勾选 = 窗口模式（fullscreen_overlay=false），取消 = 全屏模式。
+                        // 覆盖层活跃时禁止切换，避免模式与运行中的 overlay 不一致。
+                        let state = app.state::<AppState>();
+                        if state
+                            .overlay_active
+                            .load(std::sync::atomic::Ordering::SeqCst)
+                        {
+                            let locale = current_locale(&state);
+                            tracing::warn!(
+                                "拒绝切换窗口模式：{}",
+                                tr(locale, "overlay_active_cannot_change_mode")
+                            );
+                            return;
+                        }
+
                         let tray_state = app.state::<TrayMenuState>();
                         let is_window_mode =
                             tray_state.window_mode_item.is_checked().unwrap_or(false);
@@ -608,11 +628,25 @@ fn relaunch_app(app: tauri::AppHandle) {
 /// - 写入配置文件、更新内存快照、广播给 overlay。
 /// - locale 变化时更新托盘菜单文本并广播事件。
 /// - fullscreen_overlay / live_drag_preview 变化时同步托盘勾选状态。
+/// - 若 overlay 处于活跃状态且请求切换 fullscreen_overlay，则拒绝变更并返回错误，
+///   防止运行中的覆盖层与目标模式不一致。
 #[tauri::command]
 async fn update_preferences(
     app: tauri::AppHandle,
     preferences: PreferencesPatch,
 ) -> Result<(), String> {
+    // 覆盖层运行时禁止切换覆盖模式。
+    if preferences.fullscreen_overlay.is_some() {
+        let state = app.state::<AppState>();
+        if state
+            .overlay_active
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            let locale = current_locale(&state);
+            return Err(tr(locale, "overlay_active_cannot_change_mode"));
+        }
+    }
+
     update_preferences_inner(app, preferences).await
 }
 

--- a/src/ConfigApp.tsx
+++ b/src/ConfigApp.tsx
@@ -385,14 +385,19 @@ export default function ConfigApp() {
 
         {/* 底部固定区：覆盖模式 + 目标窗口 + 开始/停止覆盖 */}
         <div className="space-y-3 shrink-0">
-          {/* 窗口模式勾选（默认全屏，勾选切换为窗口模式） */}
+          {/* 窗口模式勾选（默认全屏，勾选切换为窗口模式）。覆盖层激活时禁止切换，避免状态不一致。 */}
           <div className="flex items-center gap-2">
             <Checkbox
               id="window-mode"
               checked={!config.settings.fullscreen_overlay}
+              disabled={overlayActive}
+              title={overlayActive ? t("overlay.windowModeBlockedHint") : undefined}
               onCheckedChange={(v) => updateSettings({ fullscreen_overlay: !v })}
             />
-            <Label htmlFor="window-mode" className="text-sm cursor-pointer">
+            <Label
+              htmlFor="window-mode"
+              className={`text-sm ${overlayActive ? "text-muted-foreground cursor-not-allowed" : "cursor-pointer"}`}
+            >
               {t("overlaySettings.windowMode")}
             </Label>
           </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -18,6 +18,7 @@
   "overlay": {
     "autoSwitchTitle": "Hide config window and switch to game?",
     "autoSwitchDesc": "After starting the overlay, the config window will be hidden and focus will switch to the target game window. You can restore it from the tray.",
+    "windowModeBlockedHint": "Overlay is active. Stop the overlay before changing the mode.",
     "rememberChoice": "Remember my choice",
     "switchYes": "Yes, hide and switch",
     "switchNo": "No, keep config window visible",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -18,6 +18,7 @@
   "overlay": {
     "autoSwitchTitle": "是否自动隐藏配置窗口并切换到游戏？",
     "autoSwitchDesc": "开始覆盖后将隐藏配置窗口并将焦点切换到目标游戏窗口，需要时可从托盘恢复。",
+    "windowModeBlockedHint": "覆盖层运行中，请先停止覆盖层再切换模式",
     "rememberChoice": "下次记住选择",
     "switchYes": "是，自动隐藏并切换",
     "switchNo": "否，保持配置窗口显示",


### PR DESCRIPTION
## 描述

当前代码在「覆盖层已开启」的状态下，如果用户触发「切换为窗口模式」，该场景没有任何逻辑分支处理：程序既不会阻止切换，也不会自动关闭覆盖层后再切换，导致状态不一致或行为未定义。

本 PR 禁止在覆盖层激活时切换窗口模式：

- **前端**：「窗口模式」复选框在 overlay 激活时置灰，并在 hover 时提示「覆盖层运行中，请先停止覆盖层再切换模式」。
- **后端**： command 与托盘「窗口模式」菜单项均增加  校验，若覆盖层运行中则拒绝切换并记录日志。
- **文案**：新增中英文提示 。

## 关联 Issue

Closes #2
