### PR TITLE
docs: add language switcher links to README and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+[English](CHANGELOG.md) · [简体中文](CHANGELOG.zh-cn.md)
+
 Only stable releases are recorded here. For beta / prerelease versions, see **[CHANGELOG_ALPHA.md](CHANGELOG_ALPHA.md)**.
 
 ---

--- a/CHANGELOG.zh-cn.md
+++ b/CHANGELOG.zh-cn.md
@@ -1,5 +1,7 @@
 # 更新日志
 
+[English](CHANGELOG.md) · [简体中文](CHANGELOG.zh-cn.md)
+
 仅记录正式版本发布。测试版 / 预览版本见 **[CHANGELOG_ALPHA.zh-cn.md](CHANGELOG_ALPHA.zh-cn.md)**。
 
 ---

--- a/CHANGELOG_ALPHA.md
+++ b/CHANGELOG_ALPHA.md
@@ -1,5 +1,7 @@
 # Alpha Changelog
 
+[English](CHANGELOG_ALPHA.md) · [简体中文](CHANGELOG_ALPHA.zh-cn.md)
+
 The following versions are preview and development iterations before the stable release. They are intended for testing and feedback only.
 
 For the stable release changelog, see **[CHANGELOG.md](CHANGELOG.md)**.

--- a/CHANGELOG_ALPHA.zh-cn.md
+++ b/CHANGELOG_ALPHA.zh-cn.md
@@ -1,5 +1,7 @@
 # 测试版更新日志
 
+[English](CHANGELOG_ALPHA.md) · [简体中文](CHANGELOG_ALPHA.zh-cn.md)
+
 以下版本为正式版发布前的测试与开发迭代，仅供预览与反馈。
 
 正式版日志见 **[CHANGELOG.zh-cn.md](CHANGELOG.zh-cn.md)**。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing Guide
 
+[English](CONTRIBUTING.md) · [简体中文](CONTRIBUTING.zh-cn.md)
+
 Thank you for considering contributing to Peregrine! This document explains the process and guidelines for participating in the project.
 
 ---

--- a/CONTRIBUTING.zh-cn.md
+++ b/CONTRIBUTING.zh-cn.md
@@ -1,5 +1,7 @@
 # 贡献指南
 
+[English](CONTRIBUTING.md) · [简体中文](CONTRIBUTING.zh-cn.md)
+
 感谢你考虑为 Peregrine 贡献代码！本文档说明了参与项目的流程与规范。
 
 ---

--- a/HELP.md
+++ b/HELP.md
@@ -1,5 +1,7 @@
 # Peregrine Help
 
+[English](HELP.md) · [简体中文](HELP.zh-cn.md)
+
 This document is for **end users**. It explains what Peregrine is, how to use it, and how each visual anchor style works and can be adjusted. For development-related information, see [README](README.md).
 
 ---

--- a/HELP.zh-cn.md
+++ b/HELP.zh-cn.md
@@ -1,5 +1,7 @@
 # Peregrine 使用帮助
 
+[English](HELP.md) · [简体中文](HELP.zh-cn.md)
+
 本文档面向**使用者**，介绍 Peregrine 是什么、怎么用，以及每种视觉锚点样式的作用和调节方法。开发相关信息请看 [README](README.zh-cn.md)。
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Peregrine
 
+[English](README.md) · [简体中文](README.zh-cn.md)
+
 [![Download](https://img.shields.io/github/v/release/Eeymoo/peregrine?style=for-the-badge&label=Download)](https://github.com/Eeymoo/peregrine/releases)
 
 Peregrine is a desktop utility focused on relieving 3D motion sickness. It provides customizable visual anchors on your screen—such as crosshairs, borders, and edge arrows—to help players maintain visual stability during fast camera movement or complex scenes, reducing nausea and dizziness caused by vestibular-visual conflict. This lets you comfortably play games that often trigger motion sickness, such as *Half-Life 2*, *Mirror's Edge*, *Dying Light*, and *No Man's Sky*.

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1,5 +1,7 @@
 # Peregrine
 
+[English](README.md) · [简体中文](README.zh-cn.md)
+
 [![下载](https://img.shields.io/github/v/release/Eeymoo/peregrine?style=for-the-badge&label=%E4%B8%8B%E8%BD%BD)](https://github.com/Eeymoo/peregrine/releases)
 
 Peregrine 是一款专注于缓解 3D 眩晕（Motion Sickness）的桌面工具。它通过在屏幕上提供可定制的视觉锚点（如十字准星、边框、边缘箭头等），帮助玩家在快速转动视角或复杂场景中保持视觉稳定，减轻前庭-视觉冲突带来的恶心、头晕症状。让你能够正常游玩《半条命 2》《镜之边缘》《消逝的光芒》《无人深空》等容易引发眩晕的游戏。


### PR DESCRIPTION
为 README、CONTRIBUTING、HELP、CHANGELOG 及其中文版本添加中英文切换链接。AGENTS.md 保持原样，不添加语言切换。