### PR TITLE
ci: 新增 PR 快照构建与 opencode 触发工作流

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/big-pickle

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -65,7 +65,9 @@ jobs:
         run: npm ci
 
       # 同步版本号到 Cargo.toml / package.json / tauri.conf.json。
-      - name: Sync version
+      # 同时关闭 createUpdaterArtifacts 并清空 updater pubkey：PR 快照不签名也不
+      # 走自动更新，必须关闭该项，否则 Tauri 检测到 pubkey 后会强制要求私钥而失败。
+      - name: Sync version & disable updater signing
         shell: bash
         env:
           VERSION: ${{ steps.meta.outputs.version }}
@@ -73,7 +75,7 @@ jobs:
           echo "Syncing version: $VERSION"
           sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
           node -e "const fs=require('fs');const p=require('./package.json');p.version='$VERSION';fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n')"
-          node -e "const fs=require('fs');const p=require('./src-tauri/tauri.conf.json');p.version='$VERSION';fs.writeFileSync('./src-tauri/tauri.conf.json',JSON.stringify(p,null,2)+'\n')"
+          node -e "const fs=require('fs');const p=require('./src-tauri/tauri.conf.json');p.version='$VERSION';p.bundle.createUpdaterArtifacts=false;delete p.plugins.updater.pubkey;fs.writeFileSync('./src-tauri/tauri.conf.json',JSON.stringify(p,null,2)+'\n')"
 
       # PR 构建不签名（不设置 TAURI_SIGNING_PRIVATE_KEY），仅产出未签名 NSIS。
       - name: Build Tauri (NSIS, unsigned)

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -87,6 +87,7 @@ jobs:
         env:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
+          $VERSION = "$env:VERSION"
           $nsisDir = "target/${{ matrix.target }}/release/bundle/nsis"
           $setup = Get-ChildItem "$nsisDir/*-setup.exe" | Select-Object -First 1
           if ($setup) {
@@ -102,6 +103,7 @@ jobs:
         env:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
+          $VERSION = "$env:VERSION"
           $srcExe = "target/${{ matrix.target }}/release/peregrine-tauri.exe"
           $dstExe = "peregrine-${VERSION}.exe"
           Copy-Item $srcExe $dstExe

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,116 @@
+name: Snapshot
+
+# 在提交 PR 到 main/master 时触发，构建 Windows 快照制品（NSIS + 便携 zip）用于测试。
+# 版本号取 PR head commit 短 hash（格式 0.0.0-dev.<short_sha>），不签名、不发布正式
+# GitHub Release。制品作为 workflow artifact 上传，可在 PR 检查页面下载。复用
+# release.yml 的构建逻辑，但去掉签名与发布步骤，便于在无签名密钥的 PR 上下文中产出
+# 可安装 / 可运行的测试包。也支持手动 workflow_dispatch 触发。
+on:
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Snapshot ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: i686-pc-windows-msvc
+            asset_name: windows-x86
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset_name: windows-x64
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            asset_name: windows-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 版本号取 PR head commit 短 hash（手动触发时回退到当前 commit），包装为合法
+      # semver 0.0.0-dev.<short_sha>，以满足 Tauri / NSIS 对版本号的格式要求。
+      - name: Compute snapshot version
+        id: meta
+        shell: bash
+        run: |
+          SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          SHORT="${SHA:0:7}"
+          VERSION="0.0.0-dev.${SHORT}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Snapshot version: $VERSION (sha: $SHA)"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: snapshot-${{ matrix.target }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      # 同步版本号到 Cargo.toml / package.json / tauri.conf.json。
+      - name: Sync version
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          echo "Syncing version: $VERSION"
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+          node -e "const fs=require('fs');const p=require('./package.json');p.version='$VERSION';fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n')"
+          node -e "const fs=require('fs');const p=require('./src-tauri/tauri.conf.json');p.version='$VERSION';fs.writeFileSync('./src-tauri/tauri.conf.json',JSON.stringify(p,null,2)+'\n')"
+
+      # PR 构建不签名（不设置 TAURI_SIGNING_PRIVATE_KEY），仅产出未签名 NSIS。
+      - name: Build Tauri (NSIS, unsigned)
+        shell: bash
+        run: npx tauri build --target ${{ matrix.target }} --bundles nsis
+
+      - name: Rename NSIS installer
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          $nsisDir = "target/${{ matrix.target }}/release/bundle/nsis"
+          $setup = Get-ChildItem "$nsisDir/*-setup.exe" | Select-Object -First 1
+          if ($setup) {
+            $dst = "peregrine-${VERSION}-${{ matrix.asset_name }}-setup.exe"
+            Copy-Item $setup.FullName $dst
+          } else {
+            Write-Host "::error::No NSIS installer found"
+            exit 1
+          }
+
+      - name: Create portable zip
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          $srcExe = "target/${{ matrix.target }}/release/peregrine-tauri.exe"
+          $dstExe = "peregrine-${VERSION}.exe"
+          Copy-Item $srcExe $dstExe
+          $zip = "peregrine-${VERSION}-${{ matrix.asset_name }}.zip"
+          Compress-Archive -Path $dstExe, README.md, LICENSE -DestinationPath $zip
+
+      - name: Upload snapshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-${{ matrix.asset_name }}
+          path: |
+            peregrine-${{ steps.meta.outputs.version }}-${{ matrix.asset_name }}-setup.exe
+            peregrine-${{ steps.meta.outputs.version }}-${{ matrix.asset_name }}.zip
+          if-no-files-found: error


### PR DESCRIPTION
## 变更内容

新增两个 GitHub Actions 工作流：

### 1. `snapshot.yml` — PR 快照构建
- **触发**：PR 到 main/master，或手动 `workflow_dispatch`
- **功能**：构建 Windows 三架构（x86/x64/arm64）NSIS 安装包 + 便携 zip，作为测试制品
- **版本号**：`0.0.0-dev.<7位sha>`（取 PR head commit 短 hash），合法 semver，避免与正式版本号混淆
- **制品**：作为 workflow artifact 上传，可在 PR 检查页 → Artifacts 下载（保留 90 天）
- **与 release.yml 区别**：不签名、不发布 GitHub Release、不生成 updater manifest

### 2. `opencode.yml` — opencode agent 触发器
- **触发**：在 issue 或 PR 评论 `/oc` / `/opencode` 时
- **用途**：调用 opencode agent 自动处理任务

## 验证方式
合并后在任意 PR 上 `snapshot.yml` 会自动运行；评论 `/oc` 会触发 `opencode.yml`。

## 关联
无关联 issue，纯 CI 基础设施。