### PR TITLE
release: v0.1.15-alpha.0

### DIFF
--- a/CHANGELOG_ALPHA.md
+++ b/CHANGELOG_ALPHA.md
@@ -8,11 +8,17 @@ For the stable release changelog, see **[CHANGELOG.md](CHANGELOG.md)**.
 
 ---
 
-## [Unreleased]
+## [v0.1.15-alpha.0] — 2026-07-17
+
+### Added
+
+- **Quick color reset**: Added a "Reset" button next to the quick color presets title that restores the 5 default colors in one click. [#3](https://github.com/Eeymoo/peregrine/issues/3)
+- **Per-style default crosshair presets**: Built-in crosshair styles now provide out-of-the-box default parameters (size, thickness, offset, opacity, etc.) instead of sharing one global default, so switching styles no longer yields invisible or unusable crosshairs. The frontend reverts to style-specific defaults when the user changes the style, keeping preview and overlay WYSIWYG. [#4](https://github.com/Eeymoo/peregrine/issues/4)
 
 ### Fixed
 
-- Fixed "Live Drag Preview" not updating the crosshair position in real time during window dragging: the follower thread moved the overlay window but never notified the renderer to refresh, so the crosshair stayed frozen until the mouse was released. The follower now requests a redraw via the event loop proxy whenever it repositions the overlay. [#5](https://github.com/Eeymoo/peregrine/issues/5)
+- Fixed "Live Drag Preview" not updating the crosshair position in real time during window dragging: the follower thread moved the overlay window but never notified the renderer to refresh, so the crosshair stayed frozen until the mouse was released. The follower now requests a redraw directly via `window.request_redraw()` whenever it repositions the overlay. [#5](https://github.com/Eeymoo/peregrine/issues/5)
+- Fixed window mode toggle desync when the overlay is active: Tauri v2's `CheckMenuItem` auto-toggles the checkbox before the menu event fires, so rejecting the switch left the tray checkbox out of sync with the actual config. The tray checkbox is now reverted when the guard blocks. Switching window mode (fullscreen/windowed) while the overlay is running is now blocked in the tray menu, the backend `update_preferences` command, and the frontend (checkbox disabled with tooltip). [#2](https://github.com/Eeymoo/peregrine/issues/2)
 
 ## [v0.1.9-alpha.0] — 2026-07-13
 

--- a/CHANGELOG_ALPHA.zh-cn.md
+++ b/CHANGELOG_ALPHA.zh-cn.md
@@ -8,11 +8,17 @@
 
 ---
 
-## [Unreleased]
+## [v0.1.15-alpha.0] — 2026-07-17
+
+### 新增
+
+- **快捷颜色重置**：在快捷颜色标题右侧新增「重置」按钮，一键恢复 5 个默认色值。[#3](https://github.com/Eeymoo/peregrine/issues/3)
+- **各样式开箱即用默认参数**：内置准心样式现各自提供合理的默认参数（尺寸、厚度、偏移、透明度等），切换样式后即可直接看到效果，不再出现不可见或不可用的情况。前端切换样式时重置为对应样式默认值，保证预览与覆盖层 WYSIWYG。[#4](https://github.com/Eeymoo/peregrine/issues/4)
 
 ### 修复
 
-- 修复「拖拽时实时显示」开启后拖拽过程中准心位置不实时更新的问题：follower 线程在移动 overlay 窗口后未通知渲染线程刷新，导致准心位置静止、仅松开鼠标后才跳转。现已在每次调整 overlay 位置后通过事件循环代理请求重绘。[#5](https://github.com/Eeymoo/peregrine/issues/5)
+- 修复「拖拽时实时显示」开启后拖拽过程中准心位置不实时更新的问题：follower 线程在移动 overlay 窗口后未通知渲染线程刷新，导致准心位置静止、仅松开鼠标后才跳转。现已在每次调整 overlay 位置后直接调用 `window.request_redraw()` 请求重绘。[#5](https://github.com/Eeymoo/peregrine/issues/5)
+- 修复覆盖层活跃时切换窗口模式导致托盘勾选状态不同步的问题：Tauri v2 的 `CheckMenuItem` 在菜单事件触发前已自动切换勾选状态，拒绝切换时 checkbox 会与实际配置不一致。现已在 guard 阻断时回退勾选状态。覆盖层运行时切换窗口模式（全屏/窗口）现已在托盘菜单、后端 `update_preferences` 命令、前端（禁用复选框并提示）三处统一阻断。[#2](https://github.com/Eeymoo/peregrine/issues/2)
 
 ## [v0.1.9-alpha.0] — 2026-07-13
 


### PR DESCRIPTION
发布 v0.1.15-alpha.0 预发布版本，更新 CHANGELOG_ALPHA（中英双语）。

本次预发布包含 4 个改动：
- feat: 快捷颜色支持一键恢复默认色值 (#3 / PR #7)
- fix(config): 内置准心样式开箱即用默认参数 (#4 / PR #8)
- fix(overlay): 拖拽实时显示开启后准心位置不实时更新 (#5 / PR #14)
- fix(overlay): 覆盖层运行时禁止切换窗口模式 (#2 / PR #9)

合并后将打 tag v0.1.15-alpha.0 触发 release.yml。