### PR TITLE
ci: 移除 macOS/Linux 构建 + 新增 Issue/PR 自动打标签工作流

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,55 @@
+name: Auto Labeler
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = (context.payload.issue || context.payload.pull_request).title.toLowerCase();
+            const body = ((context.payload.issue || context.payload.pull_request).body || '').toLowerCase();
+            const text = title + ' ' + body;
+
+            const rules = [
+              { keywords: ['bug', '错误', '崩溃', 'crash', 'panic', 'fix', '修复', 'broken', '不工作'], label: 'bug' },
+              { keywords: ['feat', 'feature', 'enhancement', '新增', '改进', '建议', '需求', '请求', '新功能', 'improvement'], label: 'enhancement' },
+              { keywords: ['docs', 'documentation', '文档', 'readme', 'help', '帮助', 'usage', 'guide'], label: 'documentation' },
+              { keywords: ['duplicate', '重复', 'same as'], label: 'duplicate' },
+              { keywords: ['good first issue', '新手', '初学者', 'beginner', 'easy', '简单', 'first'], label: 'good first issue' },
+              { keywords: ['help wanted', '求助', '需要帮助', '帮忙'], label: 'help wanted' },
+              { keywords: ['question', '问题', '疑问', 'how to', '如何', '咨询', 'ask'], label: 'question' },
+              { keywords: ['invalid', '无效', 'not a bug', 'not relevant'], label: 'invalid' },
+              { keywords: ['wontfix', '不修复', 'no plan', 'won\'t fix'], label: 'wontfix' },
+            ];
+
+            const labelsToAdd = [];
+            for (const rule of rules) {
+              for (const keyword of rule.keywords) {
+                if (text.includes(keyword)) {
+                  labelsToAdd.push(rule.label);
+                  break;
+                }
+              }
+            }
+
+            if (labelsToAdd.length > 0) {
+              const issueNumber = (context.payload.issue || context.payload.pull_request).number;
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: labelsToAdd,
+              });
+              console.log(`Added labels: ${labelsToAdd.join(', ')} to #${issueNumber}`);
+            }


### PR DESCRIPTION
### 变更

1. **CI**: 移除 macOS/Linux 构建，仅保留 Windows 平台
2. **自动打标签**: 新 Issue/PR 根据标题和内容自动添加标签（bug/enhancement/documentation/duplicate/good first issue/help wanted/question/invalid/wontfix）

### 说明

-  现在只构建 Windows x86_64
-  在 issue opened 和 PR opened/reopened 时根据关键词匹配自动打标签