### PR TITLE
ci: PR 到 dev 分支也触发 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: CI
 
-# 每次 push 到 main/master 分支或提交 PR 时触发，
+# 每次 push 到 main/master/dev 分支或提交 PR 时触发，
 # 验证 Windows 平台编译与测试通过。
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
技术 PR：把 ci.yml 的 dev 触发规则同步到 main 默认分支。

必要前置 for #24。同 #23 但目标分支不同。