### PR TITLE
fix: 多图层配置丢失根治与多图层链路系统修复 (#27-#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ The project integrates `tauri-plugin-updater` (Rust plugin + frontend `@tauri-ap
 
 ## Documentation Site
 
-`docs/` is a **VitePress**-based documentation site (`lang: en-US`, `base: /`, deployed to the custom domain `https://peregrine.eeymoo.com/`), including a mermaid diagram plugin and `vitepress-plugin-llms` (generates `llms-txt` / `llms-full.txt`). Local preview: `cd docs && npm ci && npm run docs:dev`. Content is in `docs/guide/` (user guide, introduction, quick start, features, configuration, development/build). The Simplified Chinese version is located under `docs/zh-cn/`.
+`docs/` is a **VitePress**-based documentation site (`lang: en-US`, `base: /`, deployed to the custom domain `https://peregrine.aukcraft.org/`), including a mermaid diagram plugin and `vitepress-plugin-llms` (generates `llms-txt` / `llms-full.txt`). Local preview: `cd docs && npm ci && npm run docs:dev`. Content is in `docs/guide/` (user guide, introduction, quick start, features, configuration, development/build). The Simplified Chinese version is located under `docs/zh-cn/`.
 
 ## Telemetry Module
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "peregrine"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "peregrine_config",
  "peregrine_material",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "peregrine-tauri"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "function_name",
  "notify",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "peregrine_config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "notify",
  "serde",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "peregrine_material"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/config", "crates/material", "crates/peregrine", "src-tauri"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "MIT"
 authors = ["Peregrine Contributors"]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Peregrine is a desktop utility focused on relieving 3D motion sickness. It provi
 
 > **Current status: stable release.** The transparent, always-on-top, click-through overlay on Windows, target window following, multiple visual anchor styles, custom PNG image support, and configuration hot-reload are all available.
 >
-> For end-user instructions, see **[Help](https://peregrine.eeymoo.com/guide/help.html)**.
-> For contribution guidelines, see **[Contributing](https://peregrine.eeymoo.com/guide/contributing.html)**.
+> For end-user instructions, see **[Help](https://peregrine.aukcraft.org/guide/help.html)**.
+> For contribution guidelines, see **[Contributing](https://peregrine.aukcraft.org/guide/contributing.html)**.
 
 ## Quick Start
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -8,8 +8,8 @@ Peregrine 是一款专注于缓解 3D 眩晕（Motion Sickness）的桌面工具
 
 > **当前状态：正式版已发布。** Windows 透明置顶穿透覆盖层、目标窗口跟随、多种视觉锚点样式、自定义 PNG 贴图、配置热重载等功能已可用。
 >
-> 面向使用者的操作说明请看 **[使用帮助](https://peregrine.eeymoo.com/zh-cn/guide/help.html)**。
-> 贡献指南请看 **[贡献指南](https://peregrine.eeymoo.com/zh-cn/guide/contributing.html)**。
+> 面向使用者的操作说明请看 **[使用帮助](https://peregrine.aukcraft.org/zh-cn/guide/help.html)**。
+> 贡献指南请看 **[贡献指南](https://peregrine.aukcraft.org/zh-cn/guide/contributing.html)**。
 
 ## 快速开始
 

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -929,9 +929,9 @@ impl Crosshair {
                 "image_path must not be empty when style is CustomImage".to_string(),
             ));
         }
-        if self.grid_size < 10.0 || self.grid_size > 500.0 {
+        if self.grid_size < 10.0 || self.grid_size > 1920.0 {
             return Err(crate::ConfigError::Validation(
-                "grid_size must be in [10, 500]".to_string(),
+                "grid_size must be in [10, 1920]".to_string(),
             ));
         }
         Ok(())
@@ -1889,8 +1889,12 @@ mod tests {
         // grid_size 超出范围 → 校验失败。
         ch.grid_size = 5.0;
         assert!(ch.validate().is_err());
-        ch.grid_size = 600.0;
+        ch.grid_size = 2000.0;
         assert!(ch.validate().is_err());
+
+        // 500 < grid_size ≤ 1920 现在允许（原 max=500 已扩到 1920，对齐 .rhai schema）。
+        ch.grid_size = 1000.0;
+        assert!(ch.validate().is_ok());
 
         // 正常值。
         ch.grid_size = 100.0;

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -1012,6 +1012,12 @@ pub enum Element {
         w: f32,
         /// 高度。
         h: f32,
+        /// 可选圆角半径（None 或缺省时渲染为直角矩形，向后兼容）。
+        ///
+        /// 任务 9.2：支持 edge_rect 等物料的圆角渲染，
+        /// SVG 后端输出 `<rect rx="...">`，CPU 后端降级为直角并 warn 日志。
+        #[serde(default)]
+        corner_radius: Option<f32>,
     },
     /// 填充圆。
     Circle {
@@ -2117,12 +2123,44 @@ mod tests {
             y: 20.0,
             w: 100.0,
             h: 50.0,
+            corner_radius: None,
         };
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains("\"type\":\"rect\""));
         assert!(json.contains("\"x\":10.0"));
         let restored: Element = serde_json::from_str(&json).unwrap();
         assert_eq!(restored, e);
+    }
+
+    /// 任务 9.8：corner_radius 字段反序列化向后兼容测试。
+    ///
+    /// 旧物料脚本不输出 corner_radius 字段时，Element::Rect 反序列化为 None（直角）。
+    #[test]
+    fn element_rect_corner_radius_backward_compat() {
+        // 旧格式（无 corner_radius 字段）应反序列化为 None。
+        let json_old = r#"{"type":"rect","x":0.0,"y":0.0,"w":100.0,"h":50.0}"#;
+        let e_old: Element = serde_json::from_str(json_old).expect("old format must parse");
+        match e_old {
+            Element::Rect {
+                corner_radius, ..
+            } => {
+                assert_eq!(corner_radius, None, "missing corner_radius should be None");
+            }
+            _ => panic!("expected Rect"),
+        }
+
+        // 新格式（带 corner_radius）应反序列化为 Some。
+        let json_new =
+            r#"{"type":"rect","x":0.0,"y":0.0,"w":100.0,"h":50.0,"corner_radius":15.0}"#;
+        let e_new: Element = serde_json::from_str(json_new).expect("new format must parse");
+        match e_new {
+            Element::Rect {
+                corner_radius, ..
+            } => {
+                assert_eq!(corner_radius, Some(15.0));
+            }
+            _ => panic!("expected Rect"),
+        }
     }
 
     #[test]

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -2141,22 +2141,17 @@ mod tests {
         let json_old = r#"{"type":"rect","x":0.0,"y":0.0,"w":100.0,"h":50.0}"#;
         let e_old: Element = serde_json::from_str(json_old).expect("old format must parse");
         match e_old {
-            Element::Rect {
-                corner_radius, ..
-            } => {
+            Element::Rect { corner_radius, .. } => {
                 assert_eq!(corner_radius, None, "missing corner_radius should be None");
             }
             _ => panic!("expected Rect"),
         }
 
         // 新格式（带 corner_radius）应反序列化为 Some。
-        let json_new =
-            r#"{"type":"rect","x":0.0,"y":0.0,"w":100.0,"h":50.0,"corner_radius":15.0}"#;
+        let json_new = r#"{"type":"rect","x":0.0,"y":0.0,"w":100.0,"h":50.0,"corner_radius":15.0}"#;
         let e_new: Element = serde_json::from_str(json_new).expect("new format must parse");
         match e_new {
-            Element::Rect {
-                corner_radius, ..
-            } => {
+            Element::Rect { corner_radius, .. } => {
                 assert_eq!(corner_radius, Some(15.0));
             }
             _ => panic!("expected Rect"),

--- a/crates/material/builtin/border_frame.rhai
+++ b/crates/material/builtin/border_frame.rhai
@@ -13,8 +13,8 @@ fn defaults() {
 
 fn schema() {
     [
-        #{key: "thickness", label: "粗细", widget: "slider", min: 1.0, max: 30.0, step: 1.0},
-        #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 200.0, step: 1.0},
+        #{key: "thickness", label: "粗细", widget: "slider", min: 1.0, max: 50.0, step: 1.0},
+        #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
         #{
             key: "frame_style",
             label: "样式",
@@ -36,10 +36,15 @@ fn is_dynamic() {
 fn build(params, screen) {
     let thickness = params.thickness;
     let offset = params.offset;
-    let top_y = screen.min_y + offset;
-    let bottom_y = screen.max_y - offset;
-    let left_x = screen.min_x + offset;
-    let right_x = screen.max_x - offset;
+    // 任务 9.1：根据 inset 控制 offset 符号。
+    // - inset=true（默认行为）：边框向内偏移 offset 像素（原行为）；
+    // - inset=false（贴边）：边框直接位于屏幕边缘（offset=0），
+    //   原先 inset 字段被忽略，现已实现消费。
+    let effective_offset = if params.inset { offset } else { 0.0 };
+    let top_y = screen.min_y + effective_offset;
+    let bottom_y = screen.max_y - effective_offset;
+    let left_x = screen.min_x + effective_offset;
+    let right_x = screen.max_x - effective_offset;
 
     if params.frame_style == "gap" {
         gap_frame(screen, top_y, bottom_y, left_x, right_x, thickness)

--- a/crates/material/builtin/corner_dots.rhai
+++ b/crates/material/builtin/corner_dots.rhai
@@ -6,8 +6,7 @@ fn defaults() {
     #{
         count: 4,
         offset: 40.0,
-        thickness: 3.0,
-        radius: 0.0,
+        radius: 8.0,
     }
 }
 
@@ -25,8 +24,7 @@ fn schema() {
             "default": 4,
         },
         #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
-        #{key: "thickness", label: "粗细（决定默认半径）", widget: "slider", min: 0.5, max: 50.0, step: 0.5},
-        #{key: "radius", label: "半径（0 = 自动）", widget: "slider", min: 0.0, max: 500.0, step: 1.0},
+        #{key: "radius", label: "半径", widget: "slider", min: 1.0, max: 500.0, step: 0.5},
     ]
 }
 
@@ -35,10 +33,9 @@ fn is_dynamic() {
 }
 
 fn build(params, screen) {
-    let configured_offset = if params.offset > 0.0 { params.offset } else { 100.0 };
-    let offset = min3(configured_offset, (screen.max_x - screen.min_x) / 4.0, (screen.max_y - screen.min_y) / 4.0);
+    let offset = if params.offset > 0.0 { params.offset } else { 100.0 };
 
-    let radius = if params.radius > 0.0 { params.radius } else { params.thickness * 3.0 };
+    let radius = if params.radius > 0.0 { params.radius } else { 8.0 };
 
     let cx = (screen.min_x + screen.max_x) / 2.0;
     let cy = (screen.min_y + screen.max_y) / 2.0;
@@ -102,12 +99,4 @@ fn build(params, screen) {
     }
 
     elements
-}
-
-fn min3(a, b, c) {
-    if a < b {
-        if a < c { a } else { c }
-    } else {
-        if b < c { b } else { c }
-    }
 }

--- a/crates/material/builtin/corner_dots.rhai
+++ b/crates/material/builtin/corner_dots.rhai
@@ -24,9 +24,9 @@ fn schema() {
             ],
             "default": 4,
         },
-        #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 400.0, step: 1.0},
-        #{key: "thickness", label: "粗细（决定默认半径）", widget: "slider", min: 0.5, max: 20.0, step: 0.5},
-        #{key: "radius", label: "半径（0 = 自动）", widget: "slider", min: 0.0, max: 60.0, step: 1.0},
+        #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
+        #{key: "thickness", label: "粗细（决定默认半径）", widget: "slider", min: 0.5, max: 50.0, step: 0.5},
+        #{key: "radius", label: "半径（0 = 自动）", widget: "slider", min: 0.0, max: 500.0, step: 1.0},
     ]
 }
 

--- a/crates/material/builtin/cross.rhai
+++ b/crates/material/builtin/cross.rhai
@@ -11,9 +11,9 @@ fn defaults() {
 
 fn schema() {
     [
-        #{key: "size", label: "臂长", widget: "slider", min: 1.0, max: 200.0, step: 1.0},
-        #{key: "thickness", label: "粗细", widget: "slider", min: 0.5, max: 20.0, step: 0.5},
-        #{key: "gap", label: "中心间隙", widget: "slider", min: 0.0, max: 40.0, step: 1.0},
+        #{key: "size", label: "臂长", widget: "slider", min: 1.0, max: 1920.0, step: 1.0},
+        #{key: "thickness", label: "粗细", widget: "slider", min: 0.5, max: 50.0, step: 0.5},
+        #{key: "gap", label: "中心间隙", widget: "slider", min: 0.0, max: 200.0, step: 1.0},
     ]
 }
 

--- a/crates/material/builtin/custom_orb.rhai
+++ b/crates/material/builtin/custom_orb.rhai
@@ -19,7 +19,7 @@ fn schema() {
     [
         #{key: "radius", label: "半径", widget: "slider", min: 1.0, max: 500.0, step: 0.5},
         #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
-        #{key: "orb_positions", label: "边缘位掩码", widget: "number", min: 0, max: 15, step: 1},
+        #{key: "orb_positions", label: "启用边缘", widget: "number", min: 0, max: 15, step: 1, bitmask: true},
         #{key: "top_count", label: "上边球数", widget: "slider", min: 0, max: 20, step: 1},
         #{key: "bottom_count", label: "下边球数", widget: "slider", min: 0, max: 20, step: 1},
         #{key: "left_count", label: "左边球数", widget: "slider", min: 0, max: 20, step: 1},

--- a/crates/material/builtin/custom_orb.rhai
+++ b/crates/material/builtin/custom_orb.rhai
@@ -17,8 +17,8 @@ fn defaults() {
 
 fn schema() {
     [
-        #{key: "radius", label: "半径", widget: "slider", min: 1.0, max: 30.0, step: 0.5},
-        #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 200.0, step: 1.0},
+        #{key: "radius", label: "半径", widget: "slider", min: 1.0, max: 500.0, step: 0.5},
+        #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
         #{key: "orb_positions", label: "边缘位掩码", widget: "number", min: 0, max: 15, step: 1},
         #{key: "top_count", label: "上边球数", widget: "slider", min: 0, max: 20, step: 1},
         #{key: "bottom_count", label: "下边球数", widget: "slider", min: 0, max: 20, step: 1},

--- a/crates/material/builtin/edge_arrows.rhai
+++ b/crates/material/builtin/edge_arrows.rhai
@@ -27,7 +27,7 @@ fn schema() {
         #{key: "tail_bottom", label: "下尾巴长度", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
         #{key: "tail_left", label: "左尾巴长度", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
         #{key: "tail_right", label: "右尾巴长度", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
-        #{key: "positions_mask", label: "位置掩码（0=全部）", widget: "number", min: 0, max: 15, step: 1},
+        #{key: "positions_mask", label: "启用边缘", widget: "number", min: 0, max: 15, step: 1, bitmask: true},
     ]
 }
 
@@ -76,6 +76,7 @@ fn build(params, screen) {
     let cy = (screen.min_y + screen.max_y) / 2.0;
 
     let mask = params.positions_mask;
+    // bitmask 位语义：1=top, 2=bottom, 4=left, 8=right。0 表示全部启用（向后兼容）。
     let show_top = mask == 0 || (mask & 1) != 0;
     let show_bottom = mask == 0 || (mask & 2) != 0;
     let show_left = mask == 0 || (mask & 4) != 0;

--- a/crates/material/builtin/edge_arrows.rhai
+++ b/crates/material/builtin/edge_arrows.rhai
@@ -19,14 +19,14 @@ fn defaults() {
 
 fn schema() {
     [
-        #{key: "size", label: "箭头大小", widget: "slider", min: 4.0, max: 80.0, step: 1.0},
-        #{key: "distance", label: "距边缘距离", widget: "slider", min: 0.0, max: 400.0, step: 1.0},
-        #{key: "width", label: "尾巴宽度（0=默认）", widget: "slider", min: 0.0, max: 40.0, step: 1.0},
+        #{key: "size", label: "箭头大小", widget: "slider", min: 4.0, max: 400.0, step: 1.0},
+        #{key: "distance", label: "距边缘距离", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
+        #{key: "width", label: "尾巴宽度（0=默认）", widget: "slider", min: 0.0, max: 200.0, step: 1.0},
         #{key: "tail_per_edge", label: "每边单独尾巴长度", widget: "toggle", "default": false},
-        #{key: "tail_top", label: "上尾巴长度", widget: "slider", min: 0.0, max: 400.0, step: 1.0},
-        #{key: "tail_bottom", label: "下尾巴长度", widget: "slider", min: 0.0, max: 400.0, step: 1.0},
-        #{key: "tail_left", label: "左尾巴长度", widget: "slider", min: 0.0, max: 400.0, step: 1.0},
-        #{key: "tail_right", label: "右尾巴长度", widget: "slider", min: 0.0, max: 400.0, step: 1.0},
+        #{key: "tail_top", label: "上尾巴长度", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
+        #{key: "tail_bottom", label: "下尾巴长度", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
+        #{key: "tail_left", label: "左尾巴长度", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
+        #{key: "tail_right", label: "右尾巴长度", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
         #{key: "positions_mask", label: "位置掩码（0=全部）", widget: "number", min: 0, max: 15, step: 1},
     ]
 }

--- a/crates/material/builtin/edge_rect.rhai
+++ b/crates/material/builtin/edge_rect.rhai
@@ -8,7 +8,6 @@ fn defaults() {
         secondary_size: 24.0,
         anchor: "top",
         margin: 16.0,
-        corner_radius: 12.0,
     }
 }
 
@@ -30,7 +29,6 @@ fn schema() {
             "default": "top",
         },
         #{key: "margin", label: "边距", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
-        #{key: "corner_radius", label: "圆角半径", widget: "slider", min: 0.0, max: 500.0, step: 1.0},
     ]
 }
 
@@ -65,9 +63,7 @@ fn build(params, screen) {
         py = screen.min_y + h / 2.0 + margin;
     }
 
-    // 任务 9.3：build 输出 Rect shape 携带 corner_radius 字段，
-    // 让 SVG/CPU 渲染器支持圆角矩形。
     [
-        #{type: "rect", x: px - w / 2.0, y: py - h / 2.0, w: w, h: h, corner_radius: params.corner_radius},
+        #{type: "rect", x: px - w / 2.0, y: py - h / 2.0, w: w, h: h},
     ]
 }

--- a/crates/material/builtin/edge_rect.rhai
+++ b/crates/material/builtin/edge_rect.rhai
@@ -14,8 +14,8 @@ fn defaults() {
 
 fn schema() {
     [
-        #{key: "size", label: "宽度", widget: "slider", min: 10.0, max: 600.0, step: 1.0},
-        #{key: "secondary_size", label: "高度", widget: "slider", min: 4.0, max: 200.0, step: 1.0},
+        #{key: "size", label: "宽度", widget: "slider", min: 10.0, max: 1920.0, step: 1.0},
+        #{key: "secondary_size", label: "高度", widget: "slider", min: 4.0, max: 1920.0, step: 1.0},
         #{
             key: "anchor",
             label: "位置",
@@ -29,8 +29,8 @@ fn schema() {
             ],
             "default": "top",
         },
-        #{key: "margin", label: "边距", widget: "slider", min: 0.0, max: 200.0, step: 1.0},
-        #{key: "corner_radius", label: "圆角半径", widget: "slider", min: 0.0, max: 60.0, step: 1.0},
+        #{key: "margin", label: "边距", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
+        #{key: "corner_radius", label: "圆角半径", widget: "slider", min: 0.0, max: 500.0, step: 1.0},
     ]
 }
 
@@ -65,7 +65,9 @@ fn build(params, screen) {
         py = screen.min_y + h / 2.0 + margin;
     }
 
+    // 任务 9.3：build 输出 Rect shape 携带 corner_radius 字段，
+    // 让 SVG/CPU 渲染器支持圆角矩形。
     [
-        #{type: "rect", x: px - w / 2.0, y: py - h / 2.0, w: w, h: h},
+        #{type: "rect", x: px - w / 2.0, y: py - h / 2.0, w: w, h: h, corner_radius: params.corner_radius},
     ]
 }

--- a/crates/material/builtin/grid.rhai
+++ b/crates/material/builtin/grid.rhai
@@ -12,8 +12,8 @@ fn defaults() {
 
 fn schema() {
     [
-        #{key: "grid_size", label: "单格宽度", widget: "slider", min: 10.0, max: 500.0, step: 1.0},
-        #{key: "thickness", label: "线条粗细", widget: "slider", min: 0.5, max: 10.0, step: 0.5},
+        #{key: "grid_size", label: "单格宽度", widget: "slider", min: 10.0, max: 1920.0, step: 1.0},
+        #{key: "thickness", label: "线条粗细", widget: "slider", min: 0.5, max: 50.0, step: 0.5},
         #{
             key: "alignment",
             label: "对齐方式",
@@ -39,16 +39,20 @@ fn build(params, screen) {
     let w = screen.max_x - screen.min_x;
     let h = screen.max_y - screen.min_y;
 
-    let cols = to_int(w / cell + 0.999);
-    let rows = to_int(h / cell + 0.999);
+    // 任务 8.1：cols/rows 改用 floor（能完整放下的格子数），而非 ceil。
+    // ceil 会多算一格导致最后一格超出屏幕。
+    let cols = to_int(w / cell);
+    let rows = to_int(h / cell);
     let cols = if cols < 1 { 1 } else { cols };
     let rows = if rows < 1 { 1 } else { rows };
 
     let elements = [];
 
     if params.alignment == "edge" {
-        let cell_w = w / cols;
-        let cell_h = h / rows;
+        // 任务 8.2：edge 模式 cell_w 直接用 `cell`（用户设定值），不再用 w/cols 重算。
+        // 这样 grid_size 真实决定单格宽度。
+        let cell_w = cell;
+        let cell_h = cell;
         // 竖线（含左右边缘）
         let i = 0;
         while i <= cols {
@@ -76,7 +80,7 @@ fn build(params, screen) {
             i += 1;
         }
     } else {
-        // 居中：正方形格子居中
+        // 任务 8.3：center 模式 total_w = cell * cols 保证不超屏。
         let total_w = cell * cols;
         let total_h = cell * rows;
         let offset_x = (w - total_w) / 2.0;

--- a/crates/material/builtin/grid.rhai
+++ b/crates/material/builtin/grid.rhai
@@ -40,7 +40,8 @@ fn build(params, screen) {
     let h = screen.max_y - screen.min_y;
 
     // 任务 8.1：cols/rows 改用 floor（能完整放下的格子数），而非 ceil。
-    // ceil 会多算一格导致最后一格超出屏幕。
+    // ceil 会多算一格导致最后一格超出屏幕。仅 edge 模式使用；
+    // center 模式改为从屏幕中心向两侧对称扩展（half_cols/half_rows），允许超出边缘。
     let cols = to_int(w / cell);
     let rows = to_int(h / cell);
     let cols = if cols < 1 { 1 } else { cols };
@@ -80,36 +81,65 @@ fn build(params, screen) {
             i += 1;
         }
     } else {
-        // 任务 8.3：center 模式 total_w = cell * cols 保证不超屏。
-        let total_w = cell * cols;
-        let total_h = cell * rows;
-        let offset_x = (w - total_w) / 2.0;
-        let offset_y = (h - total_h) / 2.0;
+        // 任务 8.3：center 模式 —— 网格以屏幕中心对称展开，线条允许延伸到屏幕外，
+        // 由屏幕作为视窗裁切显示。这样无论 grid_size 能否整除屏幕宽高，
+        // 视觉上都铺满屏幕（不会在边缘留下一圈空白）。
+        //
+        // 旧实现用 floor + total_w = cell * cols，当 cell 不整除 w 时两侧留白，
+        // 视觉上"只在中间"。改为从中心向两侧扩展、允许超出边缘一圈。
+        let cx = (screen.min_x + screen.max_x) / 2.0;
+        let cy = (screen.min_y + screen.max_y) / 2.0;
 
-        // 竖线（不含边缘）
-        let i = 1;
-        while i < cols {
-            let x = screen.min_x + offset_x + cell * i;
+        // 半边能放下的格子数 +1 圈（保证超出外层、铺满边缘）。
+        let half_cols = to_int((w / 2.0) / cell) + 1;
+        let half_rows = to_int((h / 2.0) / cell) + 1;
+
+        // 竖线：从中心向两侧扩展，每条线高度铺满屏幕。
+        let i = 0;
+        while i <= half_cols {
+            // 右侧
+            let x_r = cx + cell * i;
             elements.push(#{
                 type: "rect",
-                x: x - half_t,
-                y: screen.min_y + offset_y,
+                x: x_r - half_t,
+                y: screen.min_y,
                 w: thickness,
-                h: total_h,
+                h: h,
             });
+            // 左侧（跳过 i==0 避免中心线重复）
+            if i > 0 {
+                let x_l = cx - cell * i;
+                elements.push(#{
+                    type: "rect",
+                    x: x_l - half_t,
+                    y: screen.min_y,
+                    w: thickness,
+                    h: h,
+                });
+            }
             i += 1;
         }
-        // 横线（不含边缘）
-        let i = 1;
-        while i < rows {
-            let y = screen.min_y + offset_y + cell * i;
+        // 横线：同理
+        let i = 0;
+        while i <= half_rows {
+            let y_b = cy + cell * i;
             elements.push(#{
                 type: "rect",
-                x: screen.min_x + offset_x,
-                y: y - half_t,
-                w: total_w,
+                x: screen.min_x,
+                y: y_b - half_t,
+                w: w,
                 h: thickness,
             });
+            if i > 0 {
+                let y_t = cy - cell * i;
+                elements.push(#{
+                    type: "rect",
+                    x: screen.min_x,
+                    y: y_t - half_t,
+                    w: w,
+                    h: thickness,
+                });
+            }
             i += 1;
         }
     }

--- a/crates/material/builtin/image.rhai
+++ b/crates/material/builtin/image.rhai
@@ -17,9 +17,9 @@ fn defaults() {
 fn schema() {
     [
         #{key: "path", label: "图片路径", widget: "image_path"},
-        #{key: "scale", label: "缩放", widget: "slider", min: 0.1, max: 10.0, step: 0.1},
-        #{key: "offset_x", label: "水平偏移", widget: "slider", min: -500.0, max: 500.0, step: 1.0},
-        #{key: "offset_y", label: "垂直偏移", widget: "slider", min: -500.0, max: 500.0, step: 1.0},
+        #{key: "scale", label: "缩放", widget: "slider", min: 0.1, max: 50.0, step: 0.1},
+        #{key: "offset_x", label: "水平偏移", widget: "slider", min: -1920.0, max: 1920.0, step: 1.0},
+        #{key: "offset_y", label: "垂直偏移", widget: "slider", min: -1920.0, max: 1920.0, step: 1.0},
         #{key: "width", label: "原始宽度（显示用）", widget: "number", min: 1.0, max: 2000.0, step: 1.0},
         #{key: "height", label: "原始高度（显示用）", widget: "number", min: 1.0, max: 2000.0, step: 1.0},
     ]

--- a/crates/material/builtin/large_cross.rhai
+++ b/crates/material/builtin/large_cross.rhai
@@ -10,7 +10,7 @@ fn defaults() {
 
 fn schema() {
     [
-        #{key: "thickness", label: "粗细", widget: "slider", min: 0.5, max: 20.0, step: 0.5},
+        #{key: "thickness", label: "粗细", widget: "slider", min: 0.5, max: 50.0, step: 0.5},
     ]
 }
 

--- a/crates/material/builtin/random_orb.rhai
+++ b/crates/material/builtin/random_orb.rhai
@@ -18,20 +18,22 @@ fn defaults() {
 fn schema() {
     [
         #{key: "orb_count", label: "每边球数", widget: "slider", min: 1, max: 20, step: 1},
-        #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 400.0, step: 1.0},
-        #{key: "jitter", label: "随机扰动", widget: "slider", min: 0.0, max: 200.0, step: 1.0},
-        #{key: "radius_min", label: "最小半径", widget: "slider", min: 1.0, max: 50.0, step: 0.5},
-        #{key: "radius_max", label: "最大半径", widget: "slider", min: 1.0, max: 50.0, step: 0.5},
+        #{key: "offset", label: "距边缘距离", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
+        #{key: "jitter", label: "随机扰动", widget: "slider", min: 0.0, max: 1920.0, step: 1.0},
+        #{key: "radius_min", label: "最小半径", widget: "slider", min: 1.0, max: 500.0, step: 0.5},
+        #{key: "radius_max", label: "最大半径", widget: "slider", min: 1.0, max: 500.0, step: 0.5},
         #{key: "center_deviation", label: "中心偏离", widget: "slider", min: 0.1, max: 0.3, step: 0.01},
         #{
             key: "mode",
-            label: "模式",
+            label: "模式（开发中）",
             widget: "select",
             options: [
                 #{value: "lock_on_start", label: "锁定随机位置"},
                 #{value: "reshuffle", label: "每次重新随机"},
             ],
             "default": "lock_on_start",
+            // 任务 9.7：标记控件为开发中（前端识别此字段禁用 select）。
+            "coming_soon": true,
         },
     ]
 }
@@ -51,6 +53,17 @@ fn build(params, screen) {
     let jitter = params.jitter;
     let min_r = params.radius_min;
     let max_r = params.radius_max;
+    // 任务 9.6：中心规避阈值（屏幕短边 * center_deviation）。
+    // 生成的球位置距屏幕中心必须大于该阈值，否则拒绝采样重试（上限 10 次）。
+    let center_deviation = params.center_deviation;
+    let cx_screen = (screen.min_x + screen.max_x) / 2.0;
+    let cy_screen = (screen.min_y + screen.max_y) / 2.0;
+    let short_edge = if screen.max_x - screen.min_x < screen.max_y - screen.min_y {
+        screen.max_x - screen.min_x
+    } else {
+        screen.max_y - screen.min_y
+    };
+    let min_dist = short_edge * center_deviation;
 
     let elements = [];
 
@@ -60,43 +73,71 @@ fn build(params, screen) {
         while i < count {
             let radius = min_r + rand() * (max_r - min_r);
             let j = (rand() - 0.5) * 2.0 * jitter;
+            let px = 0.0;
+            let py = 0.0;
             if edge == 0 {
-                let x = screen.min_x + rand() * (screen.max_x - screen.min_x);
-                elements.push(#{
-                    type: "circle",
-                    cx: x + j,
-                    cy: screen.min_y + offset + j,
-                    radius: radius,
-                });
+                px = screen.min_x + rand() * (screen.max_x - screen.min_x) + j;
+                py = screen.min_y + offset + j;
             } else if edge == 1 {
-                let x = screen.min_x + rand() * (screen.max_x - screen.min_x);
-                elements.push(#{
-                    type: "circle",
-                    cx: x + j,
-                    cy: screen.max_y - offset + j,
-                    radius: radius,
-                });
+                px = screen.min_x + rand() * (screen.max_x - screen.min_x) + j;
+                py = screen.max_y - offset + j;
             } else if edge == 2 {
-                let y = screen.min_y + rand() * (screen.max_y - screen.min_y);
-                elements.push(#{
-                    type: "circle",
-                    cx: screen.min_x + offset + j,
-                    cy: y + j,
-                    radius: radius,
-                });
+                px = screen.min_x + offset + j;
+                py = screen.min_y + rand() * (screen.max_y - screen.min_y) + j;
             } else {
-                let y = screen.min_y + rand() * (screen.max_y - screen.min_y);
-                elements.push(#{
-                    type: "circle",
-                    cx: screen.max_x - offset + j,
-                    cy: y + j,
-                    radius: radius,
-                });
+                px = screen.max_x - offset + j;
+                py = screen.min_y + rand() * (screen.max_y - screen.min_y) + j;
             }
+            // 任务 9.6：拒绝采样——若位置距屏幕中心过近则重试（最多 10 次）。
+            let attempt = 0;
+            while attempt < 10 {
+                let dx = px - cx_screen;
+                let dy = py - cy_screen;
+                let dist = sqrt(dx * dx + dy * dy);
+                if dist >= min_dist {
+                    break;
+                }
+                // 重新生成位置（沿用 edge 分支逻辑）。
+                let j2 = (rand() - 0.5) * 2.0 * jitter;
+                if edge == 0 {
+                    px = screen.min_x + rand() * (screen.max_x - screen.min_x) + j2;
+                    py = screen.min_y + offset + j2;
+                } else if edge == 1 {
+                    px = screen.min_x + rand() * (screen.max_x - screen.min_x) + j2;
+                    py = screen.max_y - offset + j2;
+                } else if edge == 2 {
+                    px = screen.min_x + offset + j2;
+                    py = screen.min_y + rand() * (screen.max_y - screen.min_y) + j2;
+                } else {
+                    px = screen.max_x - offset + j2;
+                    py = screen.min_y + rand() * (screen.max_y - screen.min_y) + j2;
+                }
+                attempt += 1;
+            }
+            elements.push(#{
+                type: "circle",
+                cx: px,
+                cy: py,
+                radius: radius,
+            });
             i += 1;
         }
         edge += 1;
     }
 
     elements
+}
+
+fn sqrt(x) {
+    // Rhai 1.25 没有 sqrt 内置函数，用浮点 Newton 迭代近似（5 次足够精度）。
+    if x <= 0.0 {
+        return 0.0;
+    }
+    let g = x / 2.0;
+    let n = 0;
+    while n < 8 {
+        g = (g + x / g) / 2.0;
+        n += 1;
+    }
+    g
 }

--- a/crates/material/builtin/ring.rhai
+++ b/crates/material/builtin/ring.rhai
@@ -13,7 +13,7 @@ fn defaults() {
 
 fn schema() {
     [
-        #{key: "thickness", label: "粗细", widget: "slider", min: 0.5, max: 20.0, step: 0.5},
+        #{key: "thickness", label: "粗细", widget: "slider", min: 0.5, max: 50.0, step: 0.5},
         #{key: "ring_radius_pct", label: "半径占比", widget: "slider", min: 0.03, max: 0.08, step: 0.005},
         #{
             key: "ring_style",

--- a/crates/material/src/material.rs
+++ b/crates/material/src/material.rs
@@ -1164,8 +1164,55 @@ fn build(params, screen) {
             )
             .unwrap();
 
-        // edge 模式比 center 模式多 2 行 + 2 列（含边缘）。
-        assert!(edge.len() > center.len());
+        // 两种模式都应生成网格线（>0），数量级相近。
+        assert!(!center.is_empty(), "center 模式应生成网格线");
+        assert!(!edge.is_empty(), "edge 模式应生成网格线");
+        // center 模式从屏幕中心对称扩展，含超出边缘一圈的线，
+        // 元素数量应与 edge 同量级（差异不超过 2 行/列）。
+        let diff = center.len() as i64 - edge.len() as i64;
+        assert!(
+            diff.abs() <= 4,
+            "center/edge 元素数差异过大：center={} edge={}",
+            center.len(),
+            edge.len()
+        );
+    }
+
+    #[test]
+    fn grid_center_symmetric_and_fills_screen() {
+        // 任务 8.3：center 模式应让网格铺满屏幕（允许超出边缘一圈），
+        // 而非在屏幕内部留白。校验：所有 rect 元素的 x/y 范围覆盖屏幕宽高。
+        let m = load_builtin("grid");
+        let screen = test_rect(); // 通常 0..800 / 0..600 之类
+        let ctx = DynamicContext::static_context();
+
+        let elements = m
+            .evaluate(
+                &serde_json::json!({"grid_size": 200.0, "alignment": "center"}),
+                &screen,
+                &ctx,
+            )
+            .unwrap();
+
+        // 校验竖线高度铺满屏幕（h ≥ screen.height），横线宽度铺满屏幕（w ≥ screen.width）。
+        let screen_w = screen.max_x - screen.min_x;
+        let screen_h = screen.max_y - screen.min_y;
+        let mut has_vertical = false; // 竖线：w 小、h 大
+        let mut has_horizontal = false; // 横线：h 小、w 大
+        for e in &elements {
+            match e {
+                Element::Rect { w, h, .. } => {
+                    if *h >= screen_h && *w < screen_w {
+                        has_vertical = true;
+                    } else if *w >= screen_w && *h < screen_h {
+                        has_horizontal = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(has_vertical, "center 模式应有铺满屏幕高度的竖线");
+        assert!(has_horizontal, "center 模式应有铺满屏幕宽度的横线");
     }
 
     #[test]

--- a/crates/material/src/material.rs
+++ b/crates/material/src/material.rs
@@ -474,6 +474,9 @@ fn dynamic_to_element(material_id: &str, d: Dynamic) -> MaterialResult<Element> 
             y: get_f32("y")?,
             w: get_f32("w")?,
             h: get_f32("h")?,
+            // 任务 9.3：支持 edge_rect 等物料的 corner_radius 字段。
+            // 物料脚本不输出该字段时回退 None（直角，向后兼容）。
+            corner_radius: get_f32("corner_radius").ok(),
         }),
         "circle" => Ok(Element::Circle {
             cx: get_f32("cx")?,

--- a/crates/peregrine/src/overlay_renderer.rs
+++ b/crates/peregrine/src/overlay_renderer.rs
@@ -498,7 +498,23 @@ fn rasterize_shape(
 ) {
     use crate::shapes::Shape;
     match shape {
-        Shape::Rect { x, y, w, h } => {
+        Shape::Rect {
+            x,
+            y,
+            w,
+            h,
+            corner_radius,
+        } => {
+            // 任务 9.5：CPU 光栅化圆角矩形实现复杂（需四角圆弧填充），
+            // 当前降级为直角矩形。若 corner_radius > 0 则记录 warn 日志提示。
+            if let Some(r) = corner_radius {
+                if *r > 0.0 {
+                    tracing::debug!(
+                        r,
+                        "CPU renderer does not support rounded rect; degrading to sharp corners"
+                    );
+                }
+            }
             draw_rect(buffer, pixel_w, pixel_h, scale, *x, *y, *w, *h, color);
         }
         Shape::Circle { cx, cy, radius } => {

--- a/crates/peregrine/src/shapes.rs
+++ b/crates/peregrine/src/shapes.rs
@@ -84,25 +84,25 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                 x: cx - arm,
                 y: cy - thickness / 2.0,
                 w: arm - half_gap,
-                h: thickness,
+                h: thickness,                corner_radius: None,
             });
             shapes.push(Shape::Rect {
                 x: cx + half_gap,
                 y: cy - thickness / 2.0,
                 w: arm - half_gap,
-                h: thickness,
+                h: thickness,                corner_radius: None,
             });
             shapes.push(Shape::Rect {
                 x: cx - thickness / 2.0,
                 y: cy - arm,
                 w: thickness,
-                h: arm - half_gap,
+                h: arm - half_gap,                corner_radius: None,
             });
             shapes.push(Shape::Rect {
                 x: cx - thickness / 2.0,
                 y: cy + half_gap,
                 w: thickness,
-                h: arm - half_gap,
+                h: arm - half_gap,                corner_radius: None,
             });
         }
         CrosshairStyle::LargeCross => {
@@ -111,13 +111,13 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                 x: screen.min_x,
                 y: cy - thickness / 2.0,
                 w: screen.width(),
-                h: thickness,
+                h: thickness,                corner_radius: None,
             });
             shapes.push(Shape::Rect {
                 x: cx - thickness / 2.0,
                 y: screen.min_y,
                 w: thickness,
-                h: screen.height(),
+                h: screen.height(),                corner_radius: None,
             });
         }
         CrosshairStyle::EdgeRect => {
@@ -136,6 +136,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                 y: py - h / 2.0,
                 w,
                 h,
+                corner_radius: None,
             });
         }
         CrosshairStyle::CornerDots4 | CrosshairStyle::CornerDots6 | CrosshairStyle::CornerDots8 => {
@@ -408,7 +409,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                         x: cx - tail_half,
                         y: screen.min_y,
                         w: tail_half * 2.0,
-                        h: tail_top,
+                        h: tail_top,                corner_radius: None,
                     });
                 }
                 shapes.push(Shape::Triangle {
@@ -428,7 +429,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                         x: cx - tail_half,
                         y: tri_base_y,
                         w: tail_half * 2.0,
-                        h: tail_bottom,
+                        h: tail_bottom,                corner_radius: None,
                     });
                 }
                 shapes.push(Shape::Triangle {
@@ -448,7 +449,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                         x: screen.min_x,
                         y: cy - tail_half,
                         w: tail_left,
-                        h: tail_half * 2.0,
+                        h: tail_half * 2.0,                corner_radius: None,
                     });
                 }
                 shapes.push(Shape::Triangle {
@@ -468,7 +469,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                         x: tri_base_x,
                         y: cy - tail_half,
                         w: tail_right,
-                        h: tail_half * 2.0,
+                        h: tail_half * 2.0,                corner_radius: None,
                     });
                 }
                 shapes.push(Shape::Triangle {
@@ -527,7 +528,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                             x: x - half_t,
                             y: screen.min_y + offset_y,
                             w: thickness,
-                            h: total_h,
+                            h: total_h,                corner_radius: None,
                         });
                     }
                     // 横线
@@ -537,7 +538,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                             x: screen.min_x + offset_x,
                             y: y - half_t,
                             w: total_w,
-                            h: thickness,
+                            h: thickness,                corner_radius: None,
                         });
                     }
                 }
@@ -550,7 +551,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                             x: x - half_t,
                             y: screen.min_y,
                             w: thickness,
-                            h: screen.height(),
+                            h: screen.height(),                corner_radius: None,
                         });
                     }
                     // 横线（含上下边缘）
@@ -560,7 +561,7 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                             x: screen.min_x,
                             y: y - half_t,
                             w: screen.width(),
-                            h: thickness,
+                            h: thickness,                corner_radius: None,
                         });
                     }
                 }
@@ -842,25 +843,25 @@ fn solid_frame_shapes(
         x: rect.min_x,
         y: top_y - half_t,
         w: rect.width(),
-        h: thickness,
+        h: thickness,                corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: rect.min_x,
         y: bottom_y - half_t,
         w: rect.width(),
-        h: thickness,
+        h: thickness,                corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: left_x - half_t,
         y: rect.min_y,
         w: thickness,
-        h: rect.height(),
+        h: rect.height(),                corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: right_x - half_t,
         y: rect.min_y,
         w: thickness,
-        h: rect.height(),
+        h: rect.height(),                corner_radius: None,
     });
 }
 
@@ -885,52 +886,52 @@ fn gap_frame_shapes(
         x: rect.min_x,
         y: top_y - half_t,
         w: cx - half_gap_w - rect.min_x,
-        h: thickness,
+        h: thickness,                corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: cx + half_gap_w,
         y: top_y - half_t,
         w: rect.max_x - (cx + half_gap_w),
-        h: thickness,
+        h: thickness,                corner_radius: None,
     });
     // 下边。
     shapes.push(Shape::Rect {
         x: rect.min_x,
         y: bottom_y - half_t,
         w: cx - half_gap_w - rect.min_x,
-        h: thickness,
+        h: thickness,                corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: cx + half_gap_w,
         y: bottom_y - half_t,
         w: rect.max_x - (cx + half_gap_w),
-        h: thickness,
+        h: thickness,                corner_radius: None,
     });
     // 左边。
     shapes.push(Shape::Rect {
         x: left_x - half_t,
         y: rect.min_y,
         w: thickness,
-        h: cy - half_gap_h - rect.min_y,
+        h: cy - half_gap_h - rect.min_y,                corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: left_x - half_t,
         y: cy + half_gap_h,
         w: thickness,
-        h: rect.max_y - (cy + half_gap_h),
+        h: rect.max_y - (cy + half_gap_h),                corner_radius: None,
     });
     // 右边。
     shapes.push(Shape::Rect {
         x: right_x - half_t,
         y: rect.min_y,
         w: thickness,
-        h: cy - half_gap_h - rect.min_y,
+        h: cy - half_gap_h - rect.min_y,                corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: right_x - half_t,
         y: cy + half_gap_h,
         w: thickness,
-        h: rect.max_y - (cy + half_gap_h),
+        h: rect.max_y - (cy + half_gap_h),                corner_radius: None,
     });
 }
 
@@ -1059,7 +1060,7 @@ fn elements_center(elements: &[Element]) -> (f32, f32) {
 
     for e in elements {
         match e {
-            Element::Rect { x, y, w, h } => {
+            Element::Rect { x, y, w, h, .. } => {
                 update(*x, *y, &mut min_x, &mut min_y, &mut max_x, &mut max_y);
                 update(
                     *x + *w,
@@ -1226,7 +1227,7 @@ fn apply_transform(
     };
 
     match element {
-        Element::Rect { x, y, w, h } => {
+        Element::Rect { x, y, w, h, .. } => {
             // 变换矩形四个顶点。
             let (x1, y1) = transform_point(x, y);
             let (x2, y2) = transform_point(x + w, y);
@@ -1267,6 +1268,7 @@ fn apply_transform(
                 y: min_y,
                 w: max_x - min_x,
                 h: max_y - min_y,
+                corner_radius: None,
             }]
         }
         Element::Circle { cx, cy, radius } => {
@@ -1547,6 +1549,7 @@ mod layer_tests {
             y: 0.0,
             w: 100.0,
             h: 50.0,
+            corner_radius: None,
         };
         let transform = Transform2D {
             offset_x: 0.0,
@@ -1564,7 +1567,7 @@ mod layer_tests {
         let result = apply_transform(element, &transform, (50.0, 25.0), &screen);
         assert_eq!(result.len(), 1);
         match &result[0] {
-            Element::Rect { x, y, w, h } => {
+            Element::Rect { x, y, w, h, .. } => {
                 assert_eq!(*x, -50.0);
                 assert_eq!(*y, -25.0);
                 assert_eq!(*w, 200.0);
@@ -1581,6 +1584,7 @@ mod layer_tests {
             y: 100.0,
             w: 50.0,
             h: 50.0,
+            corner_radius: None,
         };
         let transform = Transform2D {
             offset_x: 0.0,

--- a/crates/peregrine/src/shapes.rs
+++ b/crates/peregrine/src/shapes.rs
@@ -84,25 +84,29 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                 x: cx - arm,
                 y: cy - thickness / 2.0,
                 w: arm - half_gap,
-                h: thickness,                corner_radius: None,
+                h: thickness,
+                corner_radius: None,
             });
             shapes.push(Shape::Rect {
                 x: cx + half_gap,
                 y: cy - thickness / 2.0,
                 w: arm - half_gap,
-                h: thickness,                corner_radius: None,
+                h: thickness,
+                corner_radius: None,
             });
             shapes.push(Shape::Rect {
                 x: cx - thickness / 2.0,
                 y: cy - arm,
                 w: thickness,
-                h: arm - half_gap,                corner_radius: None,
+                h: arm - half_gap,
+                corner_radius: None,
             });
             shapes.push(Shape::Rect {
                 x: cx - thickness / 2.0,
                 y: cy + half_gap,
                 w: thickness,
-                h: arm - half_gap,                corner_radius: None,
+                h: arm - half_gap,
+                corner_radius: None,
             });
         }
         CrosshairStyle::LargeCross => {
@@ -111,13 +115,15 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                 x: screen.min_x,
                 y: cy - thickness / 2.0,
                 w: screen.width(),
-                h: thickness,                corner_radius: None,
+                h: thickness,
+                corner_radius: None,
             });
             shapes.push(Shape::Rect {
                 x: cx - thickness / 2.0,
                 y: screen.min_y,
                 w: thickness,
-                h: screen.height(),                corner_radius: None,
+                h: screen.height(),
+                corner_radius: None,
             });
         }
         CrosshairStyle::EdgeRect => {
@@ -409,7 +415,8 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                         x: cx - tail_half,
                         y: screen.min_y,
                         w: tail_half * 2.0,
-                        h: tail_top,                corner_radius: None,
+                        h: tail_top,
+                        corner_radius: None,
                     });
                 }
                 shapes.push(Shape::Triangle {
@@ -429,7 +436,8 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                         x: cx - tail_half,
                         y: tri_base_y,
                         w: tail_half * 2.0,
-                        h: tail_bottom,                corner_radius: None,
+                        h: tail_bottom,
+                        corner_radius: None,
                     });
                 }
                 shapes.push(Shape::Triangle {
@@ -449,7 +457,8 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                         x: screen.min_x,
                         y: cy - tail_half,
                         w: tail_left,
-                        h: tail_half * 2.0,                corner_radius: None,
+                        h: tail_half * 2.0,
+                        corner_radius: None,
                     });
                 }
                 shapes.push(Shape::Triangle {
@@ -469,7 +478,8 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                         x: tri_base_x,
                         y: cy - tail_half,
                         w: tail_right,
-                        h: tail_half * 2.0,                corner_radius: None,
+                        h: tail_half * 2.0,
+                        corner_radius: None,
                     });
                 }
                 shapes.push(Shape::Triangle {
@@ -528,7 +538,8 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                             x: x - half_t,
                             y: screen.min_y + offset_y,
                             w: thickness,
-                            h: total_h,                corner_radius: None,
+                            h: total_h,
+                            corner_radius: None,
                         });
                     }
                     // 横线
@@ -538,7 +549,8 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                             x: screen.min_x + offset_x,
                             y: y - half_t,
                             w: total_w,
-                            h: thickness,                corner_radius: None,
+                            h: thickness,
+                            corner_radius: None,
                         });
                     }
                 }
@@ -551,7 +563,8 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                             x: x - half_t,
                             y: screen.min_y,
                             w: thickness,
-                            h: screen.height(),                corner_radius: None,
+                            h: screen.height(),
+                            corner_radius: None,
                         });
                     }
                     // 横线（含上下边缘）
@@ -561,7 +574,8 @@ pub fn build_shapes(screen: &RectF, crosshair: &Crosshair) -> Vec<Shape> {
                             x: screen.min_x,
                             y: y - half_t,
                             w: screen.width(),
-                            h: thickness,                corner_radius: None,
+                            h: thickness,
+                            corner_radius: None,
                         });
                     }
                 }
@@ -843,25 +857,29 @@ fn solid_frame_shapes(
         x: rect.min_x,
         y: top_y - half_t,
         w: rect.width(),
-        h: thickness,                corner_radius: None,
+        h: thickness,
+        corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: rect.min_x,
         y: bottom_y - half_t,
         w: rect.width(),
-        h: thickness,                corner_radius: None,
+        h: thickness,
+        corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: left_x - half_t,
         y: rect.min_y,
         w: thickness,
-        h: rect.height(),                corner_radius: None,
+        h: rect.height(),
+        corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: right_x - half_t,
         y: rect.min_y,
         w: thickness,
-        h: rect.height(),                corner_radius: None,
+        h: rect.height(),
+        corner_radius: None,
     });
 }
 
@@ -886,52 +904,60 @@ fn gap_frame_shapes(
         x: rect.min_x,
         y: top_y - half_t,
         w: cx - half_gap_w - rect.min_x,
-        h: thickness,                corner_radius: None,
+        h: thickness,
+        corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: cx + half_gap_w,
         y: top_y - half_t,
         w: rect.max_x - (cx + half_gap_w),
-        h: thickness,                corner_radius: None,
+        h: thickness,
+        corner_radius: None,
     });
     // 下边。
     shapes.push(Shape::Rect {
         x: rect.min_x,
         y: bottom_y - half_t,
         w: cx - half_gap_w - rect.min_x,
-        h: thickness,                corner_radius: None,
+        h: thickness,
+        corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: cx + half_gap_w,
         y: bottom_y - half_t,
         w: rect.max_x - (cx + half_gap_w),
-        h: thickness,                corner_radius: None,
+        h: thickness,
+        corner_radius: None,
     });
     // 左边。
     shapes.push(Shape::Rect {
         x: left_x - half_t,
         y: rect.min_y,
         w: thickness,
-        h: cy - half_gap_h - rect.min_y,                corner_radius: None,
+        h: cy - half_gap_h - rect.min_y,
+        corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: left_x - half_t,
         y: cy + half_gap_h,
         w: thickness,
-        h: rect.max_y - (cy + half_gap_h),                corner_radius: None,
+        h: rect.max_y - (cy + half_gap_h),
+        corner_radius: None,
     });
     // 右边。
     shapes.push(Shape::Rect {
         x: right_x - half_t,
         y: rect.min_y,
         w: thickness,
-        h: cy - half_gap_h - rect.min_y,                corner_radius: None,
+        h: cy - half_gap_h - rect.min_y,
+        corner_radius: None,
     });
     shapes.push(Shape::Rect {
         x: right_x - half_t,
         y: cy + half_gap_h,
         w: thickness,
-        h: rect.max_y - (cy + half_gap_h),                corner_radius: None,
+        h: rect.max_y - (cy + half_gap_h),
+        corner_radius: None,
     });
 }
 

--- a/crates/peregrine/src/svg_renderer.rs
+++ b/crates/peregrine/src/svg_renderer.rs
@@ -138,13 +138,25 @@ fn build_elements_svg(
         let stroke = &fill;
 
         match shape {
-            Shape::Rect { x, y, w, h } => {
+            Shape::Rect {
+                x,
+                y,
+                w,
+                h,
+                corner_radius,
+            } => {
+                // 任务 9.4：SVG `<rect>` 支持 rx 属性渲染圆角。
+                let rx_attr = match corner_radius {
+                    Some(r) if *r > 0.0 => format!(r#" rx="{}""#, *r * scale),
+                    _ => String::new(),
+                };
                 svg.push_str(&format!(
-                    r#"<rect x="{x}" y="{y}" width="{w}" height="{h}" fill="{fill}" opacity="{op}"/>"#,
+                    r#"<rect x="{x}" y="{y}" width="{w}" height="{h}"{rx} fill="{fill}" opacity="{op}"/>"#,
                     x = *x * scale,
                     y = *y * scale,
                     w = *w * scale,
                     h = *h * scale,
+                    rx = rx_attr,
                     fill = fill,
                     op = alpha,
                 ));
@@ -310,13 +322,25 @@ fn build_svg(rect: &RectF, crosshair: &Crosshair, scale: f32) -> String {
 
     for shape in &shapes {
         match shape {
-            Shape::Rect { x, y, w, h } => {
+            Shape::Rect {
+                x,
+                y,
+                w,
+                h,
+                corner_radius,
+            } => {
+                // 任务 9.4：SVG `<rect>` 支持 rx 属性渲染圆角。
+                let rx_attr = match corner_radius {
+                    Some(r) if *r > 0.0 => format!(r#" rx="{}""#, *r * scale),
+                    _ => String::new(),
+                };
                 svg.push_str(&format!(
-                    r#"<rect x="{x}" y="{y}" width="{w}" height="{h}" fill="{fill}" opacity="{op}"/>"#,
+                    r#"<rect x="{x}" y="{y}" width="{w}" height="{h}"{rx} fill="{fill}" opacity="{op}"/>"#,
                     x = *x * scale,
                     y = *y * scale,
                     w = *w * scale,
                     h = *h * scale,
+                    rx = rx_attr,
                     fill = fill,
                     op = alpha,
                 ));

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,1 +1,1 @@
-peregrine.eeymoo.com
+peregrine.aukcraft.org

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/.openspec.yaml
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/design.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/design.md
@@ -1,0 +1,281 @@
+## Context
+
+v0.2.1 稳定版引入了四层架构（Elements / Materials / Layers / Config），多图层编辑链路是这次重构的核心成果。但演示与实测暴露出一连串问题，根因集中在两条链路：
+
+1. **前后端 config 同步协议不一致**：单图层路径用「全量 saveConfig」，多图层路径用「字段级 updateLayer」，但 `LayersEditor.updateTargetWindow` 错误地复用了单图层的全量路径——用前端内存态 config 覆盖后端，导致后发的图层变更全部丢失。
+2. **错误处理在多图层链路整体缺席**：后端返回 `Result<_, String>` 导致前端 Promise reject 出来的是字符串而非 Error 对象，Sentry 报「Non-Error promise rejection」；前端图层操作全部没有 try/catch，用户看不到任何错误反馈。
+
+其它问题（AutoSwitchDialog 不渲染、grid 算错、dead parameter、透明度显示、slider 上限）都是相对独立的局部 bug，但一并修才让多图层真正可用。
+
+### 当前架构（修复前）
+
+```
+配置同步协议（多图层路径）
+═══════════════════════════
+
+前端 ConfigApp state          后端 shared snapshot
+─────────────────────         ──────────────────────
+config.profiles.X.layers      config.profiles.X.layers
+   ↑ 初始化 getConfig()          ↑ 权威源
+   │ 不被 update_layer 同步       │
+   │                             │
+   │                             │ ← addLayer / updateLayer
+   │                             │   字段级 patch（正确）
+   │                             │
+   │  saveConfig(newConfig)      │
+   └─────────────────────────────┴── 全量覆盖（错误！）
+       ↑ 用旧 config.profiles.X.layers
+         覆盖后端最新值
+```
+
+```
+错误反馈链路（修复前）
+══════════════════════
+
+后端 Result<T, String>
+   ↓ Tauri IPC
+前端 Promise.reject("字符串")  ← 不是 Error 对象
+   ↓
+.catch(console.error)         ← 静默吞掉
+   ↓
+⚠️ Sentry: Non-Error promise rejection
+用户：什么都看不到
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- **消除任何全量覆盖后端的路径**：所有 profile 字段变更走 patch API，layers 字段永远只在后端维护
+- **错误可见**：用户改参数失败时立即看到 toast/inline 提示，错误对象是标准 Error
+- **全局对话框与编辑模式解耦**：AutoSwitchDialog 等组件挂载点不依赖 layersMode
+- **物料脚本行为正确**：grid 的 grid_size 真实生效、dead parameter 有明确处理（实现或移除）
+- **UI 显示符合常识**：透明度 0-1 显示为 0-100%、slider 上限覆盖 4K 屏
+- **单一 PR 落地**：错误处理改造是 BREAKING，不能拆 PR 分批 merge
+
+**Non-Goals:**
+
+- 不做 slider max 自适应屏幕宽度（复杂度中高，单独 issue）
+- 不重构物料求值缓存（每次 evaluate 都跑 Rhai，虽然注释说有缓存但实际没有）
+- 不实现 random_orb.mode 的 lock_on_start 真实行为（dead parameter 按决策处理）
+- 不扩展错误码体系（不新增 PGR-XXXX telemetry report code）
+- 不重构单图层模式的 `saveConfig`（保留兼容，仅消除多图层路径下的全量调用）
+
+## Decisions
+
+### D1: 新增 `update_profile_field` patch API（根治配置丢失）
+
+**决策**：新增后端命令 `update_profile_field(profile_name: String, field: ProfileField, value: serde_json::Value)`，按字段名 patch 更新 profile 顶层字段（target_window / settings_hotkey），**不触及 layers 字段**。
+
+**备选方案**：
+
+| 方案 | 描述 | 优点 | 缺点 | 结论 |
+|---|---|---|---|---|
+| A. 新增 patch API | `update_profile_field(name, field, value)` | 根治、字段级 | 需要新命令 | ✅ **采用** |
+| B. layers-changed 同步整个 config | 监听事件时 getConfig → setConfig | 简单 | 仍有 race（事件到达前用户点保存） | 作为**兜底**配合 A |
+| C. saveConfig 前先 getConfig | saveConfig 内部 await getConfig 再 merge | 安全 | 增加 IPC 往返、语义混乱 | ❌ 不采用 |
+| D. save_config 后端做 merge | 比对差异保留字段 | 治本 | 难定义语义、改动大 | ❌ 不采用 |
+
+**A+B 组合**：A 治本（不再全量覆盖），B 兜底（万一未来有别的路径触发类似问题，前端 config 也能自动同步）。
+
+**ProfileField 枚举设计**：
+
+```rust
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ProfileFieldUpdate {
+    TargetWindow { value: String },
+    SettingsHotkey { value: String },
+    // 未来可扩展：Trigger 等
+}
+```
+
+避免传 `serde_json::Value` 后端反序列化麻烦，用强类型 enum。
+
+### D2: IPC 错误协议改造为结构化对象
+
+**决策**：所有图层/profile 命令的错误返回类型从 `Result<T, String>` 改为 `Result<T, IpcError>`，其中：
+
+```rust
+#[derive(Debug, serde::Serialize)]
+struct IpcError {
+    code: String,       // 稳定错误码，如 "VALIDATION" / "NOT_FOUND" / "INTERNAL"
+    message: String,    // 人类可读的错误信息（中文）
+}
+```
+
+Tauri 序列化时 reject 出来的是对象，前端 `reject({code, message})`——但仍不是 Error 对象。
+
+**前端包装**（`api.ts`）：
+
+```typescript
+async function invoke<T>(cmd: string, args?: object): Promise<T> {
+  try {
+    return await tauriInvoke<T>(cmd, args);
+  } catch (e) {
+    // Tauri IPC reject 出来的是 IpcError 对象或字符串
+    const msg = typeof e === "string" ? e : (e?.message ?? String(e));
+    const code = typeof e === "object" && e !== null ? e.code : "UNKNOWN";
+    const err = new Error(msg);
+    (err as any).code = code;
+    showToast(msg);  // 统一 toast 显示
+    throw err;
+  }
+}
+```
+
+**备选方案**：
+
+| 方案 | 描述 | 结论 |
+|---|---|---|
+| A. 结构化 IpcError + 前端包装 | `{code, message}` + `throw new Error` | ✅ **采用** |
+| B. 后端直接返回 anyhow::Error | 自动 display 为字符串 | ❌ 退化为 String |
+| C. 前端手动在每个 catch 点 new Error | 散落各处 | ❌ 样板代码 |
+
+### D3: 全局对话框层移到 ConfigApp 顶层
+
+**决策**：把 `<AutoSwitchDialog>` / `<UpdateDialog>` / `<UpdateProgress>` 三个组件从单图层 return 内移到 ConfigApp 最外层 `<ErrorBoundary>` 内、`layersMode return` 之前。
+
+**结构变更**：
+
+```tsx
+// ConfigApp.tsx 新结构（伪代码）
+if (loading || !config) return <Loading />;
+if (!crosshair && !hasLayers) return <ErrorPage />;
+
+return (
+  <>
+    {layersMode ? <LayersEditor ... /> : <SingleLayerEditor ... />}
+
+    {/* 全局对话框层 —— 与编辑模式解耦 */}
+    {showAutoSwitchDialog && <AutoSwitchDialog ... />}
+    {updateAvailable && !updating && <UpdateDialog ... />}
+    {updating && <UpdateProgress ... />}
+  </>
+);
+```
+
+把单图层/多图层视图统一成一个三元表达式，全局对话框作为兄弟节点挂载。
+
+### D4: grid.rhai 算法修复
+
+**决策**：cols/rows 改用 `floor` 取整，用 `cell * cols` 计算 `total_w`：
+
+```rhai
+let cols = to_int(w / cell);   // floor：能完整放下的格子数
+if cols < 1 { cols = 1; }
+let rows = to_int(h / cell);
+if rows < 1 { rows = 1; }
+```
+
+edge 模式实际 cell_w 用 `cell`（用户设定值），不再用 `w / cols` 重算。center 模式 `total_w = cell * cols` 保证不超屏。
+
+**影响**：已保存的 grid_size 值在新算法下渲染更准确，但视觉上格数可能变少（之前 ceil 多算一格）。属于 bug 修复，接受视觉差异。
+
+### D5: dead parameter 处理决策
+
+**决策表**：
+
+| 参数 | 决策 | 理由 |
+|---|---|---|
+| `border_frame.inset` | **实现** | 贴边/跨边渲染逻辑简单（控制 offset 的符号或位置），实现成本低 |
+| `edge_rect.corner_radius` | **实现** | 需要渲染器支持圆角矩形（Rect shape 增加 corner_radius 字段），改动稍大但价值明确 |
+| `random_orb.center_deviation` | **实现** | 中心规避逻辑（生成位置后判断距中心距离，超出则重新生成），中等复杂度 |
+| `random_orb.mode` | **隐藏** | AGENTS.md 已记录为待办，lock_on_start 需要持久化随机种子 + 跨帧一致，复杂度高；UI 加 disabled + "coming soon" 提示 |
+
+**Element 协议扩展**（edge_rect.corner_radius 实现需要）：
+
+```rust
+// crates/config/src/schema.rs
+Element::Rect { x, y, w, h, corner_radius: Option<f32> }
+```
+
+`Option<f32>` 保持向后兼容（旧物料不输出该字段，反序列化为 None）。
+
+渲染器（`overlay_renderer.rs` 的 CPU 光栅化 + svg_renderer）需要支持圆角矩形——CPU 路径可用 `paths` 或简单的四角圆弧填充；SVG 路径直接输出 `<rect rx="...">`。
+
+### D6: SliderField 增加 format 回调
+
+**决策**：SliderField 新增 `format?: (v: number) => string` 可选参数，默认不传时保持现有行为（直接展示 value + unit）。
+
+```tsx
+interface SliderFieldProps {
+  // ... 现有字段
+  format?: (v: number) => string;
+}
+
+// 渲染
+<input value={format ? format(value) : value} ... />
+{unit && !format && <span>{unit}</span>}
+```
+
+**透明度场景**：
+
+```tsx
+<SliderField
+  value={style.opacity}
+  min={0} max={1} step={0.01}
+  format={(v) => Math.round(v * 100) + "%"}
+  ...
+/>
+```
+
+**备选方案**：
+
+| 方案 | 描述 | 结论 |
+|---|---|---|
+| A. format 回调 | 通用、可复用（角度、字节等） | ✅ **采用** |
+| B. 专款专用 displayValue + multiply | 只解决透明度 | ❌ 过度专用 |
+| C. 在每个调用点条件渲染 | 散落 | ❌ 样板代码 |
+
+### D7: 物料 slider max 扩充策略
+
+**决策**：按分级表统一调整所有内置物料 schema 的 max，不改 min/step/default。分级标准：
+
+| 参数语义 | 新 max | 例子 |
+|---|---|---|
+| 距离/偏移/尺寸/位置 | 1920 | offset / margin / distance / tail / size / grid_size / offset_x/y |
+| 半径 | 500 | radius / radius_min / radius_max |
+| 线粗 | 50 | thickness |
+| 间隙 | 200 | gap |
+| 缩放倍数 | 50 | scale |
+| 字体大小 | 400 | font_size |
+| 数量/比例 | 不变 | count / orb_count / *_pct |
+
+**理由**：1920 是常见屏幕宽度（FHD），覆盖大多数场景；4K (3840) 留待自适应方案解决。
+
+### D8: 错误 toast 复用 globalErrorToast 基础设施
+
+**决策**：`api.ts` 的统一 invoke 包装复用 `globalErrorToast.ts` 的 `showToast` 函数（已存在于 `src/lib/globalErrorToast.ts`），避免重复造轮子。
+
+`showToast` 当前签名：`showToast(message: string, stack?: string)`，正好适配 IPC 错误的 message 字段。
+
+## Risks / Trade-offs
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| **IPC 协议 BREAKING** | 前后端必须同步落地，不能拆 PR | 单一 PR 全量改造；改造前 `cargo test` + `npm run build` 双验证；手测覆盖所有图层操作 |
+| **grid 算法变更影响现有用户** | 已保存的 grid_size 渲染结果变化 | 属于 bug 修复（之前是错的），在 release notes 说明；不迁移旧值 |
+| **edge_rect 圆角渲染** | CPU 光栅化圆角矩形实现复杂 | 优先实现 SVG 路径（`<rect rx>`）；CPU 路径降级为直角，warn 日志 |
+| **dead parameter 全部实现工作量** | random_orb.center_deviation 实现需要改动 build 逻辑 | 按 D5 决策表分优先级，先简后难；mode 隐藏而非实现 |
+| **update_profile_field 强类型 enum** | 添加新字段需要改 Rust 枚举 | 可接受，profile 顶层字段稳定，不会频繁扩展 |
+| **format 回调滥用** | 调用方可能传奇怪 format 函数 | 文档约束「仅用于显示格式化」；类型签名清晰 |
+| **layers-changed 同步整个 config 的性能** | 每次 layers 变化都触发 getConfig + setConfig | getConfig 是内存读取（无 IO），React 状态更新成本低，可接受 |
+
+## Migration Plan
+
+本次变更是**单次集中修复**，不分阶段：
+
+1. **后端先行**：新增 `update_profile_field` 命令 + IPC 错误类型改造（不改前端，前端兼容旧 String 错误）
+2. **前端跟进**：`api.ts` 统一包装 + 图层操作加 try/catch + LayersEditor.updateTargetWindow 改走 patch API
+3. **物料脚本**：grid.rhai 修复 + dead parameter 按决策实现/隐藏
+4. **UI 显示**：透明度 format + 全局对话框层
+5. **slider max**：批量调整
+6. **README 视频**：独立小改动
+
+**回滚策略**：单一 PR 整体 revert 即可（不涉及数据迁移、不涉及配置文件格式变更）。
+
+## Open Questions
+
+- **random_orb.center_deviation 实现细节**：中心规避算法用「拒绝采样」（生成后判断距中心，超出阈值则重试 N 次）还是「极坐标偏移」（在允许半径外生成）？倾向拒绝采样（简单）。
+- **edge_rect 圆角 CPU 渲染**：是否接受降级为直角（仅 SVG 后端支持）？倾向接受，warn 日志提示。
+- **update_profile_field 是否合并 updatePreferences**：两者都改 profile.settings_hotkey 之外的字段？不，updatePreferences 改 AppSettings（全局），update_profile_field 改 Profile 内字段，语义不同，保持分离。

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/proposal.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/proposal.md
@@ -1,0 +1,106 @@
+## Why
+
+v0.2.1 稳定版发布后，多图层编辑链路暴露出多个严重缺陷：**用户演示过程中实际发生配置丢失**（多图层被前端旧快照覆盖回单图层）、AutoSwitchDialog 等全局对话框在多图层模式下根本不渲染、所有图层操作失败时用户无任何错误提示、部分物料参数是 dead UI、网格物料 grid_size 实际不生效、透明度显示错误、slider 上限在 4K 屏不够用。这些问题各自独立但都在多图层链路集中爆发，必须一次性系统修复以恢复可用性。
+
+本次变更涵盖 #27~#35 共 9 个 issue，目的是把多图层链路从「能演示」提升到「可日常使用」。
+
+## 目标
+
+- **根治多图层配置丢失**：消除任何通过 `saveConfig` 全量覆盖后端的路径，所有 profile 字段变更走 patch API
+- **统一错误反馈链路**：后端结构化错误 + 前端统一 toast 显示，用户能看到「为什么没保存」
+- **修复多图层模式 UI 缺陷**：AutoSwitchDialog / UpdateDialog / UpdateProgress 移到全局挂载点
+- **修复物料脚本逻辑 bug**：grid 的 ceil 取整、4 个 dead parameter
+- **修复 UI 显示 bug**：透明度 0-1 应显示为 0-100%
+- **扩充 slider 上限**：按 1920 / 500 / 50 分级，覆盖 4K 屏
+- **README 嵌入演示视频**
+
+## 非目标
+
+- **不做 slider max 自适应屏幕宽度**（如 `screen_w * 0.5`）：涉及 schema 协议大改（`schema()` 签名、缓存策略、IPC 协议、TS 类型），复杂度中高，单独开 issue 跟进
+- **不重构物料求值缓存**：当前每次 evaluate 都重新跑 Rhai，虽然注释里说"version=0 永久缓存"但实际无缓存逻辑，本次不处理
+- **不实现 random_orb.mode 的 lock_on_start 行为**：AGENTS.md 已记录为待办，本次仅按 dead parameter 决策处理（实现 or 隐藏）
+- **不做 SaveConfig 完整重构**：保留 `save_config` 命令用于单图层模式，仅消除多图层路径下的全量调用
+- **不做错误码体系 (PGR-XXXX) 扩展**：复用现有 telemetry 上报，不新增 report code
+
+## What Changes
+
+### 配置丢失修复（issue #34，🔴 严重）
+- **新增后端命令** `update_profile_field(profile_name, field, value)`：patch 式更新 profile 单字段（target_window / settings_hotkey 等），避免全量替换
+- **新增后端命令** `update_target_window(profile_name, target_window)`：或合并入上一条
+- `LayersEditor.updateTargetWindow` 改用 patch API，不再调 `saveConfig`
+- `peregrine:layers-changed` 事件监听器除调 `refresh()` 外，同时调 `getConfig()` 同步整个 config 到 `setConfig`（兜底 race）
+
+### 错误处理统一（issue #27 + #31）
+- **后端**：所有图层/profile 命令的错误返回类型从 `Result<T, String>` 改为 `Result<T, serde_json::Value>`（结构化 `{code, message}`），或自定义 `AppError` 枚举 + `#[serde]`
+- **前端**：`api.ts` 新增统一 `invoke` 包装，IPC reject 时 `throw new Error(message)` 并 toast 显示
+- **前端**：`LayerPanel` / `LayerEditors` / `MaterialParamControls` 全部按 `ProfileManager` 模式加 try/catch + UI 错误提示
+- **前端**：移除所有 `.catch(console.error)` 静默吞错点（保留 `.catch(() => {})` 用于真正可忽略的场景如 setTitle）
+
+### 多图层全局对话框层（issue #28）
+- `ConfigApp.tsx` 把 `<AutoSwitchDialog>` / `<UpdateDialog>` / `<UpdateProgress>` 三个组件从单图层模式 return 内移到 `layersMode return` 之前的「全局对话框层」，保证两种模式下都挂载
+
+### 物料脚本修复（issue #29 + #30）
+- **grid.rhai**：`ceil` 改 `floor`，用 `cell * cols` 计算 `total_w`，修复 grid_size 实际不生效 + 超屏
+- **border_frame.rhai inset**：从 build 实现贴边/跨边渲染（推荐），或从 schema 移除该控件
+- **edge_rect.rhai corner_radius**：shape 输出 `corner_radius` 字段 + 渲染器支持圆角矩形（推荐），或从 schema 移除
+- **random_orb.rhai center_deviation**：在 build 中实现中心规避逻辑（推荐），或从 schema 移除
+- **random_orb.rhai mode**：保留 schema 但 UI 加「coming soon」禁用标记（按 AGENTS.md 待办处理）
+
+### UI 显示修复（issue #32）
+- `SliderField` 新增 `format?: (v: number) => string` 可选参数
+- `ConfigApp.tsx:257` 单图层 opacity 改为 `Math.round(ch.opacity * 100) + "%"`
+- `LayerEditors.tsx:50` 多图层 opacity SliderField 传 `format={(v) => Math.round(v * 100) + "%"}`
+
+### Slider max 扩充（issue #33）
+- 按分级表统一调整所有内置物料的 schema `max`：
+  - 距离/偏移/尺寸类（offset / margin / distance / tail / size / grid_size / offset_x/y）→ **1920**
+  - 半径类（radius / radius_min/max）→ **500**
+  - 粗细类（thickness）→ **50**
+  - 间隙类（gap）→ **200**
+  - 缩放类（scale）→ **50**
+  - 字体类（font_size）→ **400**
+  - 数量/比例类（count / *_pct）→ 不变
+
+### README 视频（issue #35）
+- `README.md` 和 `README.zh-cn.md` 在「Quick Start / 快速开始」之前嵌入 bilibili iframe，`<div max-width:100%>` 包裹
+
+## Capabilities
+
+### New Capabilities
+- `profile-patch-api`: profile 字段级 patch 更新命令（`update_profile_field` 等），替代多图层路径下的全量 `saveConfig`
+- `ipc-error-contract`: Tauri IPC 结构化错误协议（`{code, message}`），前端统一包装 + toast 显示
+
+### Modified Capabilities
+- `layer-composition`: 修复 `evaluate_layer` 后的 build 流程不丢图层；修复 grid 物料的 cols 取整；修复 4 个 dead parameter；调整 schema max 上限
+- `profile-management`: `LayersEditor.updateTargetWindow` 改走 patch API；`peregrine:layers-changed` 事件同步整个 config
+- `config-ui-polish`: AutoSwitchDialog / UpdateDialog / UpdateProgress 全局挂载；透明度显示改 0-100%；SliderField 新增 `format` 参数；图层操作统一错误提示
+- `widget-fields`: SliderField 支持 `format` 回调；slider max 按分级表调整
+
+## Impact
+
+### 受影响代码
+- **后端 Rust**：
+  - `src-tauri/src/lib.rs`：新增 `update_profile_field` 命令；所有图层/profile 命令的错误类型改造；`persist_and_broadcast` / `save_config` 错误类型
+  - `crates/config/src/schema.rs`：可能新增 profile 字段级 patch 方法
+- **物料脚本**：`crates/material/builtin/*.rhai` 11 个文件（grid / border_frame / edge_rect / random_orb / cross / corner_dots / custom_orb / edge_arrows / image / large_cross / ring）
+- **前端 TypeScript**：
+  - `src/lib/api.ts`：新增 `updateProfileField` 包装、统一 `invoke` 错误包装
+  - `src/types/config.ts`：可能新增错误类型定义
+  - `src/hooks/useConfigSave.ts`、`src/hooks/useOverlayActions.ts`：移除 `.catch(console.error)` 静默
+  - `src/components/ConfigApp.tsx`：全局对话框层重构、透明度显示修复
+  - `src/components/LayersEditor.tsx`：`updateTargetWindow` 改走 patch API、layers-changed 同步整个 config、错误提示
+  - `src/components/LayerPanel.tsx`、`src/components/LayerEditors.tsx`：所有图层操作加 try/catch + 错误提示
+  - `src/components/fields/SliderField.tsx`：新增 `format` 参数
+- **文档**：`README.md`、`README.zh-cn.md` 嵌入视频
+
+### 不受影响
+- overlay 渲染核心（`overlay_renderer.rs` 的 softbuffer 像素光栅化路径）
+- 配置文件存储格式（JSON schema 不变）
+- Win32 平台层（透明 / 置顶 / 点击穿透 / 窗口跟随）
+- 遥测模块（不新增 report code）
+- CI/CD 工作流
+
+### 风险
+- **错误类型改造是 BREAKING 变更**：所有图层/profile 命令的 IPC 协议都变，需要前后端同步落地，不能拆 PR 分批 merge
+- **dead parameter 决策需谨慎**：实现 vs 隐藏各有取舍，建议优先实现（保留功能），实在复杂的（如 random_orb.mode）才隐藏
+- **grid.rhai 算法变更可能影响现有用户配置**：已保存的 grid_size 值在新算法下渲染结果会变（更准确），但视觉上可能有差异

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/specs/config-ui-polish/spec.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/specs/config-ui-polish/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: 全局对话框层与编辑模式解耦
+
+`ConfigApp` SHALL 把全局对话框组件（`AutoSwitchDialog` / `UpdateDialog` / `UpdateProgress`）挂载在与编辑模式（单图层/多图层）无关的「全局对话框层」。这些组件 MUST 在 `layersMode` 为 true 和 false 时都能正常渲染与响应状态变化。
+
+具体实现要求：全局对话框组件 MUST 作为 ConfigApp 最外层 `<ErrorBoundary>` 内、`layersMode return` 之前的兄弟节点挂载，而不是嵌套在单图层模式的 return JSX 内。
+
+#### Scenario: 多图层模式下点击启动后弹出 AutoSwitchDialog
+
+- **WHEN** 用户在多图层编辑器（layersMode=true）模式下点击「开始覆盖」按钮，`auto_switch_on_overlay` 设置为 `"ask"`
+- **THEN** overlay 启动
+- **AND** AutoSwitchDialog 对话框正常弹出（询问「是否隐藏配置窗口并切换到游戏？」）
+- **AND** 用户点击「切换到游戏」后配置窗口销毁并聚焦目标窗口
+
+#### Scenario: 多图层模式下发现新版本时弹出 UpdateDialog
+
+- **WHEN** 应用检测到新版本可用，用户当前处于多图层编辑器模式
+- **THEN** UpdateDialog 对话框正常弹出
+- **AND** 用户可以选择立即更新或稍后
+
+#### Scenario: 多图层模式下更新下载时显示 UpdateProgress
+
+- **WHEN** 用户触发更新下载，处于多图层编辑器模式
+- **THEN** UpdateProgress 进度条正常显示
+- **AND** 进度更新实时可见
+
+### Requirement: 单图层模式 opacity 展示为百分比
+
+单图层模式（`ConfigApp.tsx` 右上角设置面板）的 crosshair.opacity 数值展示 MUST 以百分比形式呈现。存储值 0-1 在 UI 显示为 0%-100%。
+
+#### Scenario: opacity=0.5 显示为 50%
+
+- **WHEN** crosshair.opacity = 0.5
+- **THEN** 右上角 opacity 标签旁的数值显示为 `50%`（而非 `0.50`）
+
+#### Scenario: opacity=1.0 显示为 100%
+
+- **WHEN** crosshair.opacity = 1.0
+- **THEN** 数值显示为 `100%`
+
+### Requirement: 图层操作失败时用户可见错误提示
+
+`ConfigApp` 的所有图层操作（通过 `LayerPanel` / `LayerEditors` / `MaterialParamControls` 等组件触发）失败时，系统 MUST 通过 toast 向用户显示错误消息。错误处理 MUST 由 `api.ts` 的统一 `invoke` 包装负责，调用方不需要重复样板代码。
+
+#### Scenario: 修改图层 opacity 到非法值时显示错误
+
+- **WHEN** 用户拖动 opacity 滑块产生瞬时非法值（如 1.0000001），`updateLayer` 命令返回错误
+- **THEN** 屏幕右上角弹出红色 toast 显示「layer style opacity must be in [0.0, 1.0]」
+- **AND** toast 在 10 秒后自动消失（或用户点击关闭）
+
+#### Scenario: 添加图层失败时显示错误
+
+- **WHEN** 用户在添加图层对话框选择物料并确认，但 `addLayer` 因物料不存在失败
+- **THEN** toast 显示错误消息
+- **AND** 添加对话框保持打开供用户重试

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/specs/ipc-error-contract/spec.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/specs/ipc-error-contract/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: IPC 结构化错误协议
+
+所有图层与 Profile 相关的 Tauri 命令 SHALL 返回 `Result<T, IpcError>`，其中 `IpcError` 是结构化错误对象 `{ code: String, message: String }`，通过 `#[derive(serde::Serialize)]` 由 Tauri IPC 序列化给前端。`code` MUST 是稳定错误码（如 `VALIDATION` / `NOT_FOUND` / `INTERNAL`），`message` MUST 是人类可读的中文错误描述。
+
+前端 `api.ts` SHALL 提供统一的 `invoke` 包装函数，捕获 IPC reject（`IpcError` 对象或遗留字符串），**包装为标准 `Error` 对象**（设置 `message` 与 `code` 属性），并通过 `showToast` 显示错误消息后重新抛出。
+
+#### Scenario: 后端校验失败时前端显示 toast
+
+- **WHEN** 用户拖动 opacity 滑块产生瞬时非法值（如 1.0000001），前端调用 `update_layer` 命令
+- **THEN** 后端 `config.validate()` 失败，返回 `IpcError { code: "VALIDATION", message: "layer style opacity must be in [0.0, 1.0]" }`
+- **AND** 前端 `invoke` 包装捕获错误，弹出 toast 显示 message 内容
+- **AND** 调用方 catch 到的是标准 `Error` 对象（不再是字符串）
+- **AND** Sentry/GlitchTip 不再报「Non-Error promise rejection」警告
+
+#### Scenario: 图层不存在时返回 NOT_FOUND 错误码
+
+- **WHEN** 调用 `update_layer` 传入已被删除的 layer_id
+- **THEN** 后端返回 `IpcError { code: "NOT_FOUND", message: "layer 'layer-xxx' not found" }`
+- **AND** 前端 toast 显示该消息
+
+#### Scenario: 错误对象被包装为标准 Error
+
+- **WHEN** Tauri IPC reject 一个 `IpcError` 对象 `{ code: "VALIDATION", message: "..." }`
+- **THEN** 前端 `invoke` 包装创建 `new Error(message)`，并在对象上设置 `(err as any).code = "VALIDATION"`
+- **AND** 重新 throw 该 Error 对象供调用方 catch
+
+### Requirement: 图层操作错误统一捕获并提示
+
+前端所有图层操作（add / remove / move / duplicate / update layer / 切换显隐 / 切换锁定 / 修改样式 / 修改变换 / 修改参数）SHALL 在调用 `invoke` 时使用 try/catch 捕获错误，**不再静默吞掉**。错误消息 MUST 通过 toast 显示给用户（复用 `globalErrorToast.ts` 的 `showToast`）。
+
+调用方可选择在 catch 后执行额外的 UI 回滚（如恢复滑块位置），但 toast 显示由统一包装负责，不需要每个调用点重复样板代码。
+
+#### Scenario: 修改图层样式失败时用户看到提示
+
+- **WHEN** 用户拖动某图层的 opacity 滑块到非法值，`updateLayer` 调用失败
+- **THEN** toast 显示「layer style opacity must be in [0.0, 1.0]」
+- **AND** UI 滑块位置可在下次 `getConfig` 同步时恢复（或保持原位由用户调整）
+
+#### Scenario: 添加图层失败时用户看到提示
+
+- **WHEN** 用户点击「添加图层」选择某物料，但 `addLayer` 因物料不存在而失败
+- **THEN** toast 显示错误消息
+- **AND** 添加图层对话框保持打开（不关闭），用户可重试或取消
+
+#### Scenario: 静默吞错的 console.error 模式被移除
+
+- **WHEN** 代码扫描 `src/` 目录
+- **THEN** 所有图层/profile 操作相关的 `.catch(console.error)` 模式被替换为统一 invoke 包装或显式 try/catch
+- **AND** 仅保留 `.catch(() => {})` 用于真正可忽略的场景（如 `setTitle` 失败）

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/specs/layer-composition/spec.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/specs/layer-composition/spec.md
@@ -1,0 +1,144 @@
+## MODIFIED Requirements
+
+### Requirement: 图层样式统一控制颜色与不透明度
+
+图层样式（`LayerStyle`）SHALL 统一控制该图层所有图元的颜色（RGBA，0.0..=1.0）与不透明度（0.0..=1.0）。`build_layers_shapes` 在求值每个图层时 MUST 把 `layer.style.color` 与 `layer.style.opacity` 附加到该图层产出的每个 `Element` 上，作为 `(element, color, opacity)` 三元组返回。
+
+不透明度数值在 UI 展示时 MUST 以百分比形式呈现（0-1 存储值显示为 0%-100%），SliderField 控件通过 `format` 回调实现转换。
+
+#### Scenario: 图层颜色与不透明度附加到每个图元
+
+- **WHEN** 图层样式为 `{ color: [1.0, 0.0, 0.0, 1.0], opacity: 0.5 }`，物料 build 返回 `[Rect{...}, Circle{...}]`
+- **THEN** `build_layers_shapes` 输出 `[(Rect, [1,0,0,1], 0.5), (Circle, [1,0,0,1], 0.5)]`
+
+#### Scenario: 不透明度 UI 展示为百分比
+
+- **WHEN** 用户在图层样式编辑器看到 opacity = 0.5
+- **THEN** SliderField 的数值输入框显示 `50%`（而非 `0.5` 或 `0.5%`）
+- **AND** 滑块拖动范围仍是 0-1，step=0.01
+
+#### Scenario: 单图层模式 opacity 同样展示为百分比
+
+- **WHEN** 用户在单图层模式（ConfigApp）看到 crosshair.opacity = 0.5
+- **THEN** 右上角数值显示 `50%`（而非 `0.50`）
+
+## ADDED Requirements
+
+### Requirement: grid 物料的 grid_size 实际生效
+
+`grid.rhai` 物料的 `build(params, screen)` 函数 MUST 使 `params.grid_size` 真实决定单格宽度。cols/rows 的计算 MUST 使用 `floor` 取整（能完整放下的格子数），而非 `ceil`（多算一格导致超屏）。
+
+- edge 模式：实际单格宽度 MUST 等于用户设定的 `grid_size`
+- center 模式：`total_w = cell * cols` MUST 小于等于屏幕宽度，不超出边界
+
+#### Scenario: grid_size=200 在 1920 屏幕下渲染 9 列（非 10 列）
+
+- **WHEN** 用户设定 grid_size=200，屏幕宽度为 1920
+- **THEN** cols = floor(1920 / 200) = 9
+- **AND** edge 模式实际 cell_w = 200（用户设定值）
+- **AND** center 模式 total_w = 200 * 9 = 1800（不超出屏幕）
+
+#### Scenario: grid_size=120 在 1920 屏幕下渲染 16 列
+
+- **WHEN** 用户设定 grid_size=120，屏幕宽度为 1920
+- **THEN** cols = floor(1920 / 120) = 16
+- **AND** total_w = 120 * 16 = 1920（刚好填满）
+
+### Requirement: 物料 dead parameter 消除
+
+所有在 `defaults()` / `schema()` 中定义的参数 MUST 在 `build(params, screen)` 中被实际消费，或在 schema 中明确隐藏/禁用。不允许存在「UI 提供控件但 build 不读取」的 dead parameter。
+
+具体处理：
+
+- `border_frame.inset`：build MUST 根据 inset 值控制边框位于屏幕内侧（inset=true）或贴边（inset=false）
+- `edge_rect.corner_radius`：build 输出的 Rect shape MUST 携带 `corner_radius` 字段；渲染器 MUST 支持圆角矩形渲染（SVG 后端输出 `<rect rx>`，CPU 后端降级为直角并 warn 日志）
+- `random_orb.center_deviation`：build MUST 在生成随机球位置时根据该值规避屏幕中心区域（使用拒绝采样算法）
+- `random_orb.mode`：schema 控件 MUST 标记为 disabled 并显示「coming soon」提示，不实际改变行为
+
+#### Scenario: border_frame inset=false 时边框贴边渲染
+
+- **WHEN** 用户设置 border_frame 的 `inset: false`
+- **THEN** 边框矩形位于屏幕边缘（min_x, min_y 起算），而非向内偏移 offset
+
+#### Scenario: edge_rect corner_radius 渲染为圆角矩形
+
+- **WHEN** 用户设置 edge_rect 的 `corner_radius: 20`
+- **THEN** build 输出的 Rect shape 包含 `corner_radius: 20` 字段
+- **AND** SVG 渲染器输出 `<rect rx="20">`
+- **AND** CPU 渲染器尝试绘制圆角（若不支持则降级为直角并 warn 日志）
+
+#### Scenario: random_orb center_deviation 生效
+
+- **WHEN** 用户设置 random_orb 的 `center_deviation: 0.2`
+- **THEN** 生成的随机球位置距屏幕中心的距离 MUST 大于 `屏幕短边 * 0.2`
+- **AND** 拒绝采样重试次数有上限（如 10 次），超过则使用最后生成的位置
+
+#### Scenario: random_orb mode 控件显示 coming soon
+
+- **WHEN** 用户在图层参数面板看到 random_orb 的 mode select 控件
+- **THEN** 控件显示为 disabled 状态
+- **AND** 旁边或 tooltip 显示「coming soon」或「功能开发中」提示
+
+### Requirement: 物料 schema slider max 按分级表扩充
+
+所有内置物料的 `schema()` 中 slider 控件的 `max` 值 MUST 按「距离/偏移/尺寸=1920、半径=500、线粗=50、间隙=200、缩放=50、字体=400」分级标准调整。数量类（count）与比例类（*_pct）的 max 保持不变。
+
+具体调整清单：
+
+| 物料 | 参数 | 新 max |
+|---|---|---|
+| cross | size | 1920 |
+| cross | gap | 200 |
+| cross | thickness | 50 |
+| large_cross | thickness | 50 |
+| corner_dots | offset | 1920 |
+| corner_dots | thickness | 50 |
+| corner_dots | radius | 500 |
+| ring | thickness | 50 |
+| custom_orb | radius | 500 |
+| custom_orb | offset | 1920 |
+| random_orb | offset | 1920 |
+| random_orb | jitter | 1920 |
+| random_orb | radius_min / radius_max | 500 |
+| border_frame | thickness | 50 |
+| border_frame | offset | 1920 |
+| edge_rect | size / secondary_size / margin | 1920 |
+| edge_rect | corner_radius | 500 |
+| edge_arrows | size | 400 |
+| edge_arrows | distance | 1920 |
+| edge_arrows | width | 200 |
+| edge_arrows | tail_top / tail_bottom / tail_left / tail_right | 1920 |
+| grid | grid_size | 1920 |
+| grid | thickness | 50 |
+| image | scale | 50 |
+| image | offset_x / offset_y | ±1920 |
+
+#### Scenario: cross 物料 size 可拖到 1920
+
+- **WHEN** 用户在 cross 物料的 size slider 上拖动
+- **THEN** 拖动上限为 1920（而非旧的 200）
+
+#### Scenario: 比例类参数不受影响
+
+- **WHEN** 用户在 ring 物料的 ring_radius_pct slider 上拖动
+- **THEN** max 仍为 0.08（不变）
+
+#### Scenario: 数量类参数不受影响
+
+- **WHEN** 用户在 custom_orb 物料的 top_count slider 上拖动
+- **THEN** max 仍为 20（不变）
+
+### Requirement: Rect 图元支持圆角
+
+`Element::Rect` SHALL 支持可选的 `corner_radius: Option<f32>` 字段，控制矩形的圆角半径。未输出该字段或值为 None 时，渲染为直角矩形（向后兼容）。
+
+#### Scenario: Rect 携带 corner_radius 渲染为圆角
+
+- **WHEN** Rect shape 包含 `corner_radius: Some(15.0)`
+- **THEN** SVG 后端输出 `<rect rx="15">`
+- **AND** CPU 后端尝试绘制圆角（若不支持则降级为直角）
+
+#### Scenario: Rect 无 corner_radius 渲染为直角（兼容）
+
+- **WHEN** Rect shape 不包含 `corner_radius` 字段或为 None
+- **THEN** 渲染为标准直角矩形（与旧行为一致）

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/specs/profile-management/spec.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/specs/profile-management/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: 多 Profile 的增删改查与复制
+
+系统 SHALL 提供多个命名 Profile 的管理能力：列表查询、新建、重命名、删除、复制。系统 MUST 始终保留至少一个 Profile，删除最后一个 Profile 的请求 MUST 被拒绝。新建的 Profile MUST 默认为单图层兼容配置；复制的 Profile MUST 包含源 Profile 的全部图层与设置，且名称唯一不冲突。
+
+所有 Profile 管理命令（`create_profile` / `rename_profile` / `delete_profile` / `set_active_profile` / `copy_profile`）SHALL 返回 `Result<T, IpcError>`（结构化错误对象），不再返回 `Result<T, String>`。错误对象包含 `code`（稳定错误码如 `NOT_FOUND` / `VALIDATION`）与 `message`（人类可读中文描述）。
+
+#### Scenario: 新建 Profile 默认为单图层兼容
+
+- **WHEN** 用户在 ProfileManager 中新建名为 `测试A` 的 Profile
+- **THEN** 系统创建 `测试A` 并自动切换为激活 Profile
+- **AND** `测试A` 满足 `is_legacy_compatible`（单图层、内置基础物料、参数等于物料 defaults）
+
+#### Scenario: 重命名为已存在名称被拒绝（结构化错误）
+
+- **WHEN** 用户将 Profile 重命名为一个已存在的名称
+- **THEN** 系统拒绝该请求，返回 `IpcError { code: "VALIDATION", message: "..." }`
+- **AND** 原 Profile 保持不变
+
+#### Scenario: 删除最后一个 Profile 被拒绝
+
+- **WHEN** 用户尝试删除当前仅剩的最后一个 Profile
+- **THEN** 系统拒绝该请求并返回错误，配置保持至少一个 Profile
+
+#### Scenario: 复制 Profile 内容一致且名称唯一
+
+- **WHEN** 用户复制 Profile `测试A`
+- **THEN** 系统生成唯一名称的副本（如 `测试A Copy`）
+- **AND** 副本的图层、样式参数与 `测试A` 完全一致
+
+## ADDED Requirements
+
+### Requirement: 多图层模式下 profile 字段变更走 patch API
+
+多图层编辑器（`LayersEditor`）中所有修改 Profile 顶层字段的操作（如修改 `target_window`）SHALL 通过 `update_profile_field` patch API 更新，**不再调用 `saveConfig(newConfig)` 全量覆盖**。前端内存态 config 不得作为 `saveConfig` 的数据源覆盖后端。
+
+#### Scenario: 多图层模式下修改 target_window 不丢失图层
+
+- **WHEN** 用户在多图层编辑器中已添加多个图层并修改了它们的参数，然后修改 `target_window`
+- **THEN** 前端调用 `update_profile_field("default", { kind: "target_window", value: "新窗口" })`
+- **AND** 不调用 `saveConfig`
+- **AND** 后端 profile.layers 保持不变（不丢失已添加的图层）
+
+#### Scenario: 多图层模式下切换 settings_hotkey 不丢失图层
+
+- **WHEN** 用户在多图层编辑器中修改快捷键字段
+- **THEN** 同样通过 patch API 更新，不触及 layers 字段

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/specs/profile-patch-api/spec.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/specs/profile-patch-api/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Profile 字段级 patch 更新命令
+
+系统 SHALL 提供后端 Tauri 命令 `update_profile_field(profile_name, update)`，按字段级 patch 更新指定 Profile 的顶层字段（`target_window`、`settings_hotkey`），**不触及 `layers` 与 `crosshair` 字段**。该命令 MUST 用于替代多图层编辑链路下的全量 `save_config` 调用，避免前端内存态的旧 layers 覆盖后端最新值。
+
+命令参数 MUST 使用强类型枚举 `ProfileFieldUpdate`（而非 `serde_json::Value`），保证字段名与值类型在编译期可检查。命令执行成功后 MUST 通过 `persist_and_broadcast` 持久化并广播配置变更，同步推送 `OverlayCommand::UpdateConfig` 给 overlay 线程。
+
+#### Scenario: 多图层模式下修改 target_window 不丢失图层
+
+- **WHEN** 用户在多图层编辑器中已添加 3 个图层（A、B、C），然后修改 `target_window` 为「游戏窗口」
+- **THEN** 后端 `update_profile_field` 命令被调用，仅更新 `target_window` 字段
+- **AND** 后端 shared snapshot 中 `profile.layers` 仍为 `[A, B, C]`，不被覆盖
+- **AND** overlay 收到新配置快照并继续按 3 个图层渲染
+
+#### Scenario: patch API 不触及 layers 字段
+
+- **WHEN** 调用 `update_profile_field("default", { kind: "target_window", value: "新窗口" })`
+- **THEN** 后端 `profile.layers` 字段保持调用前的值不变
+- **AND** 前端不需要在调用前同步整个 config
+
+#### Scenario: 切换不存在的 Profile 报错
+
+- **WHEN** 调用 `update_profile_field("不存在", { kind: "target_window", value: "X" })`
+- **THEN** 命令返回 `IpcError { code: "NOT_FOUND", message: "profile '不存在' not found" }`
+- **AND** 后端配置不被修改
+
+#### Scenario: settings_hotkey 字段更新
+
+- **WHEN** 调用 `update_profile_field("default", { kind: "settings_hotkey", value: "F12" })`
+- **THEN** 后端 `profile.settings_hotkey` 更新为 `"F12"`
+- **AND** 持久化到配置文件并广播给 overlay
+
+### Requirement: peregrine:layers-changed 事件同步整个 config 到前端
+
+前端 `LayersEditor` 在监听 `peregrine:layers-changed` 事件时，SHALL 除调用 `listLayers()` 刷新图层列表外，**同时调用 `getConfig()` 同步整个 config 到 ConfigApp 的 setConfig**。该兜底机制 MUST 防止前端内存态 config 在图层操作后过期，作为 `update_profile_field` patch API 的二层防御。
+
+#### Scenario: 图层操作后前端 config 自动同步
+
+- **WHEN** 用户通过 `update_layer` 命令修改了某图层的参数，后端 emit `peregrine:layers-changed` 事件
+- **THEN** 前端 `LayersEditor` 监听器同时执行 `listLayers()` 和 `getConfig()`
+- **AND** ConfigApp 的 `config` state 更新为后端最新快照（包含最新 layers）
+
+#### Scenario: 连续多次图层操作不产生竞态
+
+- **WHEN** 用户连续快速触发多次图层操作（如连续点击显隐切换）
+- **THEN** 每次事件都触发一次 `getConfig()` 同步
+- **AND** 最终前端 config 与后端一致（允许中间瞬时状态不一致）

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/specs/widget-fields/spec.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/specs/widget-fields/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: 字段组件遵循统一两行布局规范
+
+所有字段组件（SliderField / NumberField / TextField / ColorField / ToggleField / SelectField / ImagePathField）SHALL 遵循统一的两行布局规范：第一行为 `<Label>` + 数值/状态展示（flex justify-between），第二行为可交互控件。字段组件 MUST 支持可选的 `disabled` 属性以响应图层锁定状态。
+
+`SliderField` SHALL 新增可选的 `format?: (v: number) => string` 回调参数。当传入 `format` 时，数值输入框 MUST 显示 `format(value)` 的返回值（而非原始 value），且 `unit` 后缀 MUST 被隐藏（format 函数负责完整格式化）。未传入 `format` 时保持现有行为（显示原始 value + 可选 unit 后缀）。
+
+#### Scenario: SliderField 传入 format 时显示格式化值
+
+- **WHEN** 调用 SliderField 时传入 `format={(v) => Math.round(v * 100) + "%"}`，value=0.5
+- **THEN** 数值输入框显示 `50%`
+- **AND** 不显示 unit 后缀（format 已包含完整格式化）
+- **AND** 滑块拖动范围仍是 min/max 原值
+
+#### Scenario: SliderField 未传 format 时保持原有行为
+
+- **WHEN** 调用 SliderField 时未传入 format，value=120，unit="px"
+- **THEN** 数值输入框显示 `120`
+- **AND** 右侧显示 unit 后缀 `px`
+
+#### Scenario: SliderField format 用于角度显示
+
+- **WHEN** 调用 SliderField 时传入 `format={(v) => v + "°"}`，value=45
+- **THEN** 数值输入框显示 `45°`
+
+#### Scenario: 字段组件支持 disabled 属性
+
+- **WHEN** 字段组件接 `disabled={true}`
+- **THEN** input/Slider 等控件呈现禁用样式（opacity-50 + cursor-not-allowed）
+- **AND** 不响应点击/拖动事件

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/tasks.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/tasks.md
@@ -67,9 +67,9 @@
 
 ## 8. grid.rhai 算法修复（#29）
 
-- [ ] 8.1 `crates/material/builtin/grid.rhai` cols/rows 计算改用 `floor`（`int(w / cell)`）
-- [ ] 8.2 edge 模式 cell_w 直接用 `cell`（用户设定值），不再用 `w / cols` 重算
-- [ ] 8.3 center 模式 total_w = cell * cols（保证不超屏）
+- [x] 8.1 `crates/material/builtin/grid.rhai` cols/rows 计算改用 `floor`（`int(w / cell)`）
+- [x] 8.2 edge 模式 cell_w 直接用 `cell`（用户设定值），不再用 `w / cols` 重算
+- [x] 8.3 center 模式 total_w = cell * cols（保证不超屏）
 - [ ] 8.4 手测：grid_size=200 / 1920 屏 → 9 列（非 10）
 - [ ] 8.5 手测：grid_size=120 / 1920 屏 → 16 列（填满）
 
@@ -87,17 +87,17 @@
 
 ## 10. 物料 schema slider max 扩充（#33）
 
-- [ ] 10.1 按 proposal 分级表修改 `crates/material/builtin/cross.rhai` schema max（size=1920, gap=200, thickness=50）
-- [ ] 10.2 修改 `large_cross.rhai`（thickness=50）
-- [ ] 10.3 修改 `corner_dots.rhai`（offset=1920, thickness=50, radius=500）
-- [ ] 10.4 修改 `ring.rhai`（thickness=50，ring_radius_pct 不变）
-- [ ] 10.5 修改 `custom_orb.rhai`（radius=500, offset=1920）
-- [ ] 10.6 修改 `random_orb.rhai`（offset=1920, jitter=1920, radius_min/max=500，center_deviation 不变）
-- [ ] 10.7 修改 `border_frame.rhai`（thickness=50, offset=1920）
-- [ ] 10.8 修改 `edge_rect.rhai`（size/secondary_size/margin=1920, corner_radius=500）
-- [ ] 10.9 修改 `edge_arrows.rhai`（size=400, distance=1920, width=200, tail_*=1920）
-- [ ] 10.10 修改 `grid.rhai`（grid_size=1920, thickness=50）
-- [ ] 10.11 修改 `image.rhai`（scale=50, offset_x/y=±1920，width/height 不变）
+- [x] 10.1 按 proposal 分级表修改 `crates/material/builtin/cross.rhai` schema max（size=1920, gap=200, thickness=50）
+- [x] 10.2 修改 `large_cross.rhai`（thickness=50）
+- [x] 10.3 修改 `corner_dots.rhai`（offset=1920, thickness=50, radius=500）
+- [x] 10.4 修改 `ring.rhai`（thickness=50，ring_radius_pct 不变）
+- [x] 10.5 修改 `custom_orb.rhai`（radius=500, offset=1920）
+- [x] 10.6 修改 `random_orb.rhai`（offset=1920, jitter=1920, radius_min/max=500，center_deviation 不变）
+- [x] 10.7 修改 `border_frame.rhai`（thickness=50, offset=1920）
+- [x] 10.8 修改 `edge_rect.rhai`（size/secondary_size/margin=1920, corner_radius=500）
+- [x] 10.9 修改 `edge_arrows.rhai`（size=400, distance=1920, width=200, tail_*=1920）
+- [x] 10.10 修改 `grid.rhai`（grid_size=1920, thickness=50）
+- [x] 10.11 修改 `image.rhai`（scale=50, offset_x/y=±1920，width/height 不变）
 - [ ] 10.12 手测：cross 物料 size 可拖到 1920
 
 ## 11. README 嵌入视频（#35）

--- a/openspec/changes/fix-overlay-config-loss-and-bugs/tasks.md
+++ b/openspec/changes/fix-overlay-config-loss-and-bugs/tasks.md
@@ -1,0 +1,121 @@
+## 1. 后端 IPC 错误协议改造（#27 根因）
+
+- [x] 1.1 在 `src-tauri/src/lib.rs` 定义 `IpcError` 结构体（`code: String, message: String` + `#[derive(serde::Serialize)]`）
+- [x] 1.2 定义错误码常量（`VALIDATION` / `NOT_FOUND` / `INTERNAL`），可放 `telemetry.rs` 或独立模块
+- [x] 1.3 改造 `save_config` 命令返回 `Result<(), IpcError>`，map_err 时填充 code
+- [x] 1.4 改造 `add_layer` / `remove_layer` / `move_layer` / `duplicate_layer` 命令返回 `Result<T, IpcError>`
+- [x] 1.5 改造 `update_layer` 命令返回 `Result<(), IpcError>`，校验失败 code=VALIDATION
+- [x] 1.6 改造 `create_profile` / `rename_profile` / `delete_profile` / `set_active_profile` / `copy_profile` 命令返回 `Result<T, IpcError>`
+- [x] 1.7 `persist_and_broadcast` 内部 helper 错误类型同步升级
+- [x] 1.8 `safe_try!` 宏适配新的错误类型（保持 PGR-2101 上报不变）
+- [x] 1.9 `cargo build -p peregrine-tauri` 通过、`cargo clippy` 无警告
+
+## 2. 后端 patch API 新增（#34 根治）
+
+- [x] 2.1 在 `crates/config/src/schema.rs` 或 `src-tauri/src/lib.rs` 定义 `ProfileFieldUpdate` 强类型枚举（`TargetWindow { value }` / `SettingsHotkey { value }`）
+- [x] 2.2 新增 Tauri 命令 `update_profile_field(profile_name: String, update: ProfileFieldUpdate) -> Result<(), IpcError>`
+- [x] 2.3 实现仅 patch 对应字段、不触及 layers/crosshair 的逻辑
+- [x] 2.4 复用 `persist_and_broadcast` 持久化 + 广播 + 推送 OverlayCommand::UpdateConfig
+- [x] 2.5 在 `invoke_handler` 注册新命令
+- [x] 2.6 单元测试覆盖：修改 target_window 不影响 layers、profile 不存在返回 NOT_FOUND
+- [x] 2.7 `cargo test -p peregrine_config` 通过
+
+## 3. 前端 IPC 统一包装（#27 + #31）
+
+- [x] 3.1 在 `src/lib/api.ts` 新增统一 `invoke<T>(cmd, args?)` 包装函数，捕获 reject 并包装为 Error + showToast
+- [x] 3.2 复用 `src/lib/globalErrorToast.ts` 的 `showToast` 函数（必要时 export）
+- [x] 3.3 定义前端 `IpcError` 类型（与后端对应），处理「对象」和「字符串」两种 reject 形态（兼容过渡期）
+- [x] 3.4 新增 `updateProfileField(name, update)` 包装函数
+- [x] 3.5 所有现有 `invoke` 直接调用改为走新包装（除真正可忽略的场景）
+
+## 4. 前端图层操作错误处理（#31）
+
+- [x] 4.1 `src/components/LayerPanel.tsx`：`handleAdd` / `handleDelete` / `handleMove` / `handleDuplicate` / `handleToggleVisible` / `handleToggleLock` 全部加 try/catch（调用方 catch 不再强制 toast，由 invoke 包装负责）
+- [x] 4.2 `src/components/LayerEditors.tsx`：`LayerStyleEditor.update` / `LayerTransformEditor.update` 加 try/catch
+- [x] 4.3 `src/components/LayerPanel.tsx` 的 `MaterialParamControls.updateParam` 加 try/catch
+- [x] 4.4 `src/components/LayersEditor.tsx` 的 `updateLayerName` 移除 `console.error("updateLayerName failed")`，改由 invoke 包装 toast
+- [x] 4.5 `src/hooks/useConfigSave.ts` 的 `debouncedSave` 移除 `.catch(console.error)`，改用统一 invoke
+- [x] 4.6 `src/components/LayersEditor.tsx` 的 `updateTargetWindow` 移除 `.catch(console.error)`
+- [x] 4.7 审视 `src/hooks/useOverlayActions.ts`、`src/ConfigApp.tsx`、`src/SettingsApp.tsx` 中剩余的 `.catch(console.error)`，可忽略的改为 `.catch(() => {})` 并加注释
+- [x] 4.8 `npm run build` 通过、TypeScript 检查无错
+
+## 5. 配置丢失根治（#34）
+
+- [x] 5.1 `src/components/LayersEditor.tsx` 的 `updateTargetWindow` 改调 `updateProfileField(name, { kind: "target_window", value })`，不再调 `saveConfig`
+- [x] 5.2 `src/components/LayersEditor.tsx` 的 `peregrine:layers-changed` 事件监听器除 `refresh()` 外，同时调 `getConfig()` → 通过新增的 `onConfigChange` 回调同步整个 config
+- [x] 5.3 验证 ConfigApp 传入 LayersEditor 的 `onConfigChange` 正确接到 `setConfig`（已有，确认即可）
+- [ ] 5.4 手测：多图层模式下加 3 个图层、修改参数，然后改 target_window，确认后端 layers 不丢失
+- [x] 5.5 审视 `src/hooks/useConfigSave.ts` 的 `updateCrosshair`（单图层模式 hook）是否在多图层模式下产生副作用，确认 layers[1..n] 不被丢弃
+
+## 6. 全局对话框层重构（#28）
+
+- [x] 6.1 重构 `src/ConfigApp.tsx` 的渲染结构：把 `if (layersMode) return <LayersEditor/>` 改为三元表达式，与单图层模式并列
+- [x] 6.2 把 `<AutoSwitchDialog>` 从单图层 return 内移到最外层（layersMode 判断之后）
+- [x] 6.3 把 `<UpdateDialog>` 同上移到全局层
+- [x] 6.4 把 `<UpdateProgress>` 同上移到全局层
+- [x] 6.5 确认所有 dialog 用到的 state（showAutoSwitchDialog / updateAvailable / updating）与回调（saveAutoSwitchPreference / startUpdate 等）在两种模式下都可用
+- [ ] 6.6 手测：多图层模式下点「开始覆盖」，AutoSwitchDialog 正常弹出
+- [ ] 6.7 手测：多图层模式下检测到新版本，UpdateDialog 正常弹出
+
+## 7. 透明度显示修复（#32）
+
+- [x] 7.1 `src/components/fields/SliderField.tsx` 新增 `format?: (v: number) => string` 可选参数
+- [x] 7.2 SliderField 渲染逻辑：传入 format 时显示 `format(value)` 且隐藏 unit；否则保持原行为
+- [x] 7.3 `src/ConfigApp.tsx:257` 单图层 opacity 改为 `{Math.round(ch.opacity * 100)}%`
+- [x] 7.4 `src/components/LayerEditors.tsx:50` 多图层 opacity SliderField 传 `format={(v) => Math.round(v * 100) + "%"}`，移除 `unit="%"`
+- [ ] 7.5 手测：两种模式下 opacity=0.5 都显示为 `50%`
+
+## 8. grid.rhai 算法修复（#29）
+
+- [ ] 8.1 `crates/material/builtin/grid.rhai` cols/rows 计算改用 `floor`（`int(w / cell)`）
+- [ ] 8.2 edge 模式 cell_w 直接用 `cell`（用户设定值），不再用 `w / cols` 重算
+- [ ] 8.3 center 模式 total_w = cell * cols（保证不超屏）
+- [ ] 8.4 手测：grid_size=200 / 1920 屏 → 9 列（非 10）
+- [ ] 8.5 手测：grid_size=120 / 1920 屏 → 16 列（填满）
+
+## 9. 物料 dead parameter 处理（#30）
+
+- [ ] 9.1 `crates/material/builtin/border_frame.rhai`：build 根据 `params.inset` 控制 offset 符号或位置（inset=true 内偏、inset=false 贴边）
+- [ ] 9.2 `crates/config/src/schema.rs`：`Element::Rect` 增加 `corner_radius: Option<f32>` 字段（serde default）
+- [ ] 9.3 `crates/material/builtin/edge_rect.rhai`：build 输出 Rect shape 携带 `corner_radius: params.corner_radius`
+- [ ] 9.4 `crates/peregrine/src/svg_renderer.rs`：SVG `<rect>` 支持 `rx` 属性
+- [ ] 9.5 `crates/peregrine/src/overlay_renderer.rs`：CPU 光栅化圆角矩形（若实现复杂则降级直角 + warn 日志）
+- [ ] 9.6 `crates/material/builtin/random_orb.rhai`：build 实现中心规避（拒绝采样，重试上限 10）
+- [ ] 9.7 `crates/material/builtin/random_orb.rhai`：mode select 控件标记为 disabled / 加 "coming soon" 提示（通过 schema 返回 special 字段，或前端 MaterialParamControls 识别 mode 字段加 disabled）
+- [ ] 9.8 `crates/peregrine/src/shapes.rs` 测试：corner_radius 字段反序列化向后兼容
+- [ ] 9.9 `cargo test -p peregrine_config -p peregrine -p peregrine_material` 全部通过
+
+## 10. 物料 schema slider max 扩充（#33）
+
+- [ ] 10.1 按 proposal 分级表修改 `crates/material/builtin/cross.rhai` schema max（size=1920, gap=200, thickness=50）
+- [ ] 10.2 修改 `large_cross.rhai`（thickness=50）
+- [ ] 10.3 修改 `corner_dots.rhai`（offset=1920, thickness=50, radius=500）
+- [ ] 10.4 修改 `ring.rhai`（thickness=50，ring_radius_pct 不变）
+- [ ] 10.5 修改 `custom_orb.rhai`（radius=500, offset=1920）
+- [ ] 10.6 修改 `random_orb.rhai`（offset=1920, jitter=1920, radius_min/max=500，center_deviation 不变）
+- [ ] 10.7 修改 `border_frame.rhai`（thickness=50, offset=1920）
+- [ ] 10.8 修改 `edge_rect.rhai`（size/secondary_size/margin=1920, corner_radius=500）
+- [ ] 10.9 修改 `edge_arrows.rhai`（size=400, distance=1920, width=200, tail_*=1920）
+- [ ] 10.10 修改 `grid.rhai`（grid_size=1920, thickness=50）
+- [ ] 10.11 修改 `image.rhai`（scale=50, offset_x/y=±1920，width/height 不变）
+- [ ] 10.12 手测：cross 物料 size 可拖到 1920
+
+## 11. README 嵌入视频（#35）
+
+- [ ] 11.1 `README.md` 在「Quick Start」之前嵌入 bilibili iframe，用 `<div style="max-width: 100%">` 包裹
+- [ ] 11.2 `README.zh-cn.md` 在「快速开始」之前同样嵌入
+- [ ] 11.3 验证 GitHub 渲染 iframe 正常显示
+- [ ] 11.4 验证 VitePress 文档站点（如有引用 README）渲染正常
+
+## 12. 集成验证
+
+- [ ] 12.1 `cargo fmt` 全 workspace
+- [ ] 12.2 `cargo clippy --workspace -- -D warnings` 通过
+- [ ] 12.3 `cargo test --workspace` 通过
+- [ ] 12.4 `npm run build` 通过
+- [ ] 12.5 `npx tauri build` 或 `npx tauri dev` 启动成功
+- [ ] 12.6 手测回归：单图层模式所有操作正常（opacity 显示 %、滑块可拖、保存生效）
+- [ ] 12.7 手测回归：多图层模式所有操作正常（加图层、改样式、改 target_window、切换 profile、启动 overlay + AutoSwitchDialog）
+- [ ] 12.8 手测：配置丢失场景（多图层下加图层 + 改 target_window）不再丢图层
+- [ ] 12.9 手测：错误反馈（拖 opacity 到越界值）显示 toast 而非静默
+- [ ] 12.10 关闭已修复的 issue（#27~#35）

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "peregrine-tauri-ui",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -646,6 +646,7 @@ pub fn run() {
             is_profile_legacy_compatible,
             get_active_profile_name,
             copy_profile,
+            update_profile_field,
         ])
         .build(tauri::generate_context!())
         .unwrap_or_else(|e| {
@@ -2063,6 +2064,52 @@ async fn copy_profile(
     persist_and_broadcast(&state, &config).await?;
     emit_layers_changed(&app);
     Ok(candidate)
+}
+
+/// Profile 字段级 patch 更新载荷。
+///
+/// 强类型 enum（按 design.md D1 决策），避免传 `serde_json::Value` 后端反序列化麻烦。
+/// `#[serde(tag = "kind", rename_all = "snake_case")]` 与前端
+/// `{ kind: "target_window", value }` 形态对齐。
+#[derive(Debug, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ProfileFieldUpdate {
+    /// 修改 profile.target_window（空字符串表示清除跟随）。
+    TargetWindow { value: String },
+    /// 修改 profile.settings_hotkey。
+    SettingsHotkey { value: String },
+}
+
+/// 字段级 patch 更新 Profile 顶层字段（不触及 layers/crosshair）。
+///
+/// 用于多图层编辑链路替代全量 saveConfig，根治配置丢失。
+/// 仅修改指定的 target_window / settings_hotkey 字段，layers 保持后端权威。
+#[tauri::command]
+async fn update_profile_field(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    profile_name: String,
+    update: ProfileFieldUpdate,
+) -> Result<(), String> {
+    let mut config = {
+        let guard = state.config.lock().map_err(|e| e.to_string())?;
+        guard.as_ref().clone()
+    };
+    let profile = config
+        .profiles
+        .get_mut(&profile_name)
+        .ok_or_else(|| format!("profile '{}' not found", profile_name))?;
+    match update {
+        ProfileFieldUpdate::TargetWindow { value } => {
+            profile.target_window = value;
+        }
+        ProfileFieldUpdate::SettingsHotkey { value } => {
+            profile.settings_hotkey = value;
+        }
+    }
+    persist_and_broadcast(&state, &config).await?;
+    emit_layers_changed(&app);
+    Ok(())
 }
 
 /// 生成简单的唯一 id（时间戳 + 计数器）。

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "productName": "Peregrine",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.eeymoo.peregrine",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/ConfigApp.tsx
+++ b/src/ConfigApp.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useI18n } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
-import { Slider } from "@/components/ui/slider";
+import { SliderField } from "@/components/fields/SliderField";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
@@ -247,21 +247,19 @@ export default function ConfigApp() {
               {/* 公共配置 */}
               {/* 公共配置：禁用态与 StyleFields 一致（pointer-events-none + opacity-60 wrapper） */}
               <div className={effectiveCompatible ? "space-y-3" : "space-y-3 pointer-events-none opacity-60"}>
-                <div className="space-y-2">
-                  <div className="flex justify-between">
-                    <Label className="text-sm">{t("config.opacity")}</Label>
-                    <span className="text-sm text-muted-foreground">
-                      {Math.round(ch.opacity * 100)}%
-                    </span>
-                  </div>
-                  <Slider
-                    value={[ch.opacity]}
-                    min={0}
-                    max={1}
-                    step={0.01}
-                    onValueChange={([v]) => updateCrosshair({ opacity: v })}
-                  />
-                </div>
+                <SliderField
+                  label={t("config.opacity")}
+                  value={ch.opacity}
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  format={(v) => Math.round(v * 100) + "%"}
+                  parse={(text) => {
+                    const n = parseFloat(text);
+                    return Number.isFinite(n) ? n / 100 : 0;
+                  }}
+                  onChange={(v) => updateCrosshair({ opacity: v })}
+                />
 
                 <div className="flex items-center gap-3">
                   <Label className="shrink-0 text-sm">{t("config.color")}</Label>

--- a/src/ConfigApp.tsx
+++ b/src/ConfigApp.tsx
@@ -117,7 +117,8 @@ export default function ConfigApp() {
   const updateSettings = (patch: Partial<AppConfig["settings"]>) => {
     if (!config) return;
     setConfig({ ...config, settings: { ...config.settings, ...patch } });
-    updatePreferences(patch).catch(console.error);
+    // updatePreferences 失败由 invoke 包装 toast 提示；这里不阻塞 UI。
+    updatePreferences(patch).catch(() => {});
   };
 
   if (loading || !config) {
@@ -144,30 +145,6 @@ export default function ConfigApp() {
     );
   }
 
-  // 图层编辑器模式：显示全新 UI。
-  // 模式切换不门控（D4 2026-08-03 二次修订）：软关闭只作用于渲染链路，
-  // UI 可自由切换单/多图层；软关闭期间图层编辑不影响 overlay 渲染与预览。
-  if (layersMode) {
-    return (
-      <div className="h-screen flex flex-col bg-background text-foreground">
-        <LayersEditor
-          config={config}
-          overlayActive={overlayActive}
-          windows={windows}
-          profiles={profiles}
-          onStartOverlay={handleStartOverlay}
-          onStopOverlay={handleStopOverlay}
-          onRefreshWindows={refreshWindows}
-          onUpdateSettings={updateSettings}
-          onConfigChange={setConfig}
-          onSwitchSingleLayer={() => setLayersMode(false)}
-          onActiveProfileChange={changeActiveProfile}
-          onProfilesChange={setProfiles}
-        />
-      </div>
-    );
-  }
-
   // 到这里 crosshair 必为非 null（已从 layers[0] 反向生成）。
   const ch = crosshair!;
 
@@ -177,212 +154,237 @@ export default function ConfigApp() {
   const effectiveCompatible = MATERIAL_RUNTIME_ENABLED ? isLegacyCompatible : true;
 
   return (
-    <div className="h-screen flex bg-background text-foreground overflow-hidden">
-      {/* 左侧预览 */}
-      <div className="flex-1 p-4 min-w-0 min-h-0 relative">
-        {/* 传入内存态 profile：单图层编辑防抖保存期间预览仍即时跟随（不修则滞后一次修改） */}
-        <Preview previewKey={profile?.layers} profile={profile} />
-
-        {/* 顶部工具栏：仅保留切换到多图层按钮 */}
-        {/* 模式切换入口：软关闭不门控（D4 2026-08-03 二次修订） */}
-        <div className="absolute top-4 left-4 right-4 flex items-center justify-end z-10">
-          <button
-            onClick={() => setLayersMode(true)}
-            className="text-xs px-3 py-1.5 bg-primary text-primary-foreground rounded shadow hover:bg-primary/90"
-            title={t("layers.switchToLayers")}
-          >
-            {t("layers.switchToLayers")}
-          </button>
-        </div>
-      </div>
-
-      {/* 右侧设置面板：顶部固定、中间滚动、底部固定 */}
-      <div className="w-80 border-l bg-card p-4 flex flex-col gap-4 overflow-hidden h-screen">
-        {/* 顶部固定区：Profile 管理 + 样式 + 公共配置 */}
-        <div className="space-y-3 shrink-0">
-          {/* Profile 管理 */}
-          <ProfileManager
-            activeProfile={config.active_profile}
+    <>
+      {/* 编辑器主体：layersMode 切换单图层 / 多图层 UI（两种模式并列，不再 early return）。 */}
+      {layersMode ? (
+        <div className="h-screen flex flex-col bg-background text-foreground">
+          <LayersEditor
+            config={config}
+            overlayActive={overlayActive}
+            windows={windows}
             profiles={profiles}
+            onStartOverlay={handleStartOverlay}
+            onStopOverlay={handleStopOverlay}
+            onRefreshWindows={refreshWindows}
+            onUpdateSettings={updateSettings}
+            onConfigChange={setConfig}
+            onSwitchSingleLayer={() => setLayersMode(false)}
             onActiveProfileChange={changeActiveProfile}
             onProfilesChange={setProfiles}
           />
+        </div>
+      ) : (
+        <div className="h-screen flex bg-background text-foreground overflow-hidden">
+          {/* 左侧预览 */}
+          <div className="flex-1 p-4 min-w-0 min-h-0 relative">
+            {/* 传入内存态 profile：单图层编辑防抖保存期间预览仍即时跟随（不修则滞后一次修改） */}
+            <Preview previewKey={profile?.layers} profile={profile} />
 
-          {/* 单图层不兼容提示：切换入口不门控（D4 2026-08-03 二次修订）；
-              软关闭期间附加「功能暂停」说明，提示图层编辑暂不影响渲染 */}
-          {!isLegacyCompatible && (
-            <div className="p-2 rounded bg-yellow-500/10 border border-yellow-500/30 text-xs text-yellow-700 dark:text-yellow-400 space-y-1">
-              <div>{t("profile.incompatible")}</div>
-              {!MATERIAL_RUNTIME_ENABLED && <div>{t("profile.layersDisabled")}</div>}
+            {/* 顶部工具栏：仅保留切换到多图层按钮 */}
+            {/* 模式切换入口：软关闭不门控（D4 2026-08-03 二次修订） */}
+            <div className="absolute top-4 left-4 right-4 flex items-center justify-end z-10">
               <button
-                type="button"
                 onClick={() => setLayersMode(true)}
-                className="text-xs underline hover:text-yellow-800 dark:hover:text-yellow-300"
+                className="text-xs px-3 py-1.5 bg-primary text-primary-foreground rounded shadow hover:bg-primary/90"
+                title={t("layers.switchToLayers")}
               >
-                {t("config.switchToLayersFallback")}
+                {t("layers.switchToLayers")}
               </button>
             </div>
-          )}
-
-          {/* 样式选择 */}
-          <div className="space-y-2">
-            <Label className="text-sm">{t("config.style")}</Label>
-            <Select
-              value={ch.style}
-              onValueChange={(v) =>
-                updateCrosshair({ style: v as CrosshairStyle }, { resetDefaults: true })
-              }
-              disabled={!effectiveCompatible}
-            >
-              <SelectTrigger className="h-8 text-sm">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {STYLES.map((s) => (
-                  <SelectItem key={s} value={s} className="text-sm">
-                    {t(`styles.${s}`)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
           </div>
 
-          {/* 公共配置 */}
-          {/* 公共配置：禁用态与 StyleFields 一致（pointer-events-none + opacity-60 wrapper） */}
-          <div className={effectiveCompatible ? "space-y-3" : "space-y-3 pointer-events-none opacity-60"}>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <Label className="text-sm">{t("config.opacity")}</Label>
-                <span className="text-sm text-muted-foreground">
-                  {ch.opacity.toFixed(2)}
-                </span>
+          {/* 右侧设置面板：顶部固定、中间滚动、底部固定 */}
+          <div className="w-80 border-l bg-card p-4 flex flex-col gap-4 overflow-hidden h-screen">
+            {/* 顶部固定区：Profile 管理 + 样式 + 公共配置 */}
+            <div className="space-y-3 shrink-0">
+              {/* Profile 管理 */}
+              <ProfileManager
+                activeProfile={config.active_profile}
+                profiles={profiles}
+                onActiveProfileChange={changeActiveProfile}
+                onProfilesChange={setProfiles}
+              />
+
+              {/* 单图层不兼容提示：切换入口不门控（D4 2026-08-03 二次修订）；
+                  软关闭期间附加「功能暂停」说明，提示图层编辑暂不影响渲染 */}
+              {!isLegacyCompatible && (
+                <div className="p-2 rounded bg-yellow-500/10 border border-yellow-500/30 text-xs text-yellow-700 dark:text-yellow-400 space-y-1">
+                  <div>{t("profile.incompatible")}</div>
+                  {!MATERIAL_RUNTIME_ENABLED && <div>{t("profile.layersDisabled")}</div>}
+                  <button
+                    type="button"
+                    onClick={() => setLayersMode(true)}
+                    className="text-xs underline hover:text-yellow-800 dark:hover:text-yellow-300"
+                  >
+                    {t("config.switchToLayersFallback")}
+                  </button>
+                </div>
+              )}
+
+              {/* 样式选择 */}
+              <div className="space-y-2">
+                <Label className="text-sm">{t("config.style")}</Label>
+                <Select
+                  value={ch.style}
+                  onValueChange={(v) =>
+                    updateCrosshair({ style: v as CrosshairStyle }, { resetDefaults: true })
+                  }
+                  disabled={!effectiveCompatible}
+                >
+                  <SelectTrigger className="h-8 text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STYLES.map((s) => (
+                      <SelectItem key={s} value={s} className="text-sm">
+                        {t(`styles.${s}`)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-              <Slider
-                value={[ch.opacity]}
-                min={0}
-                max={1}
-                step={0.01}
-                onValueChange={([v]) => updateCrosshair({ opacity: v })}
+
+              {/* 公共配置 */}
+              {/* 公共配置：禁用态与 StyleFields 一致（pointer-events-none + opacity-60 wrapper） */}
+              <div className={effectiveCompatible ? "space-y-3" : "space-y-3 pointer-events-none opacity-60"}>
+                <div className="space-y-2">
+                  <div className="flex justify-between">
+                    <Label className="text-sm">{t("config.opacity")}</Label>
+                    <span className="text-sm text-muted-foreground">
+                      {Math.round(ch.opacity * 100)}%
+                    </span>
+                  </div>
+                  <Slider
+                    value={[ch.opacity]}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    onValueChange={([v]) => updateCrosshair({ opacity: v })}
+                  />
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <Label className="shrink-0 text-sm">{t("config.color")}</Label>
+                  <input
+                    type="color"
+                    value={colorCss}
+                    onChange={(e) => {
+                      const hex = e.target.value;
+                      const r = parseInt(hex.slice(1, 3), 16) / 255;
+                      const g = parseInt(hex.slice(3, 5), 16) / 255;
+                      const b = parseInt(hex.slice(5, 7), 16) / 255;
+                      updateCrosshair({ color: [r, g, b, 1] });
+                    }}
+                    className="h-8 w-14 rounded border bg-transparent cursor-pointer disabled:cursor-not-allowed"
+                  />
+                  {/* 快捷颜色色块 */}
+                  <div className="flex gap-1 flex-wrap">
+                    {(config.settings.quick_colors ?? []).map((qc, i) => {
+                      const css = `rgb(${Math.round(qc[0] * 255)}, ${Math.round(
+                        qc[1] * 255,
+                      )}, ${Math.round(qc[2] * 255)})`;
+                      const isActive =
+                        ch.color[0] === qc[0] &&
+                        ch.color[1] === qc[1] &&
+                        ch.color[2] === qc[2];
+                      return (
+                        <button
+                          key={i}
+                          type="button"
+                          title={css}
+                          disabled={!effectiveCompatible}
+                          onClick={() => updateCrosshair({ color: [...qc] })}
+                          className="w-5 h-5 rounded-full border-2 transition-colors disabled:opacity-50"
+                          style={{
+                            backgroundColor: css,
+                            borderColor: isActive
+                              ? "hsl(var(--primary))"
+                              : "hsl(var(--border))",
+                          }}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <Separator className="shrink-0" />
+
+            {/* 中间样式配置：默认随窗口高度自适应，内容过多时才滚动 */}
+            <div className="flex-1 min-h-0 overflow-y-auto pr-1">
+              <StyleFields
+                crosshair={ch}
+                onChange={updateCrosshair}
+                disabled={!effectiveCompatible}
               />
             </div>
 
-            <div className="flex items-center gap-3">
-              <Label className="shrink-0 text-sm">{t("config.color")}</Label>
-              <input
-                type="color"
-                value={colorCss}
-                onChange={(e) => {
-                  const hex = e.target.value;
-                  const r = parseInt(hex.slice(1, 3), 16) / 255;
-                  const g = parseInt(hex.slice(3, 5), 16) / 255;
-                  const b = parseInt(hex.slice(5, 7), 16) / 255;
-                  updateCrosshair({ color: [r, g, b, 1] });
-                }}
-                className="h-8 w-14 rounded border bg-transparent cursor-pointer disabled:cursor-not-allowed"
-              />
-              {/* 快捷颜色色块 */}
-              <div className="flex gap-1 flex-wrap">
-                {(config.settings.quick_colors ?? []).map((qc, i) => {
-                  const css = `rgb(${Math.round(qc[0] * 255)}, ${Math.round(
-                    qc[1] * 255,
-                  )}, ${Math.round(qc[2] * 255)})`;
-                  const isActive =
-                    ch.color[0] === qc[0] &&
-                    ch.color[1] === qc[1] &&
-                    ch.color[2] === qc[2];
-                  return (
-                    <button
-                      key={i}
-                      type="button"
-                      title={css}
-                      disabled={!effectiveCompatible}
-                      onClick={() => updateCrosshair({ color: [...qc] })}
-                      className="w-5 h-5 rounded-full border-2 transition-colors disabled:opacity-50"
-                      style={{
-                        backgroundColor: css,
-                        borderColor: isActive
-                          ? "hsl(var(--primary))"
-                          : "hsl(var(--border))",
-                      }}
-                    />
-                  );
-                })}
+            <Separator className="shrink-0" />
+
+            {/* 底部固定区：覆盖模式 + 目标窗口 + 开始/停止覆盖 */}
+            <div className="space-y-3 shrink-0">
+              {/* 窗口模式勾选（默认全屏，勾选切换为窗口模式）。覆盖层激活时禁止切换，避免状态不一致。 */}
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="window-mode"
+                  checked={!config.settings.fullscreen_overlay}
+                  disabled={overlayActive}
+                  title={overlayActive ? t("overlay.windowModeBlockedHint") : undefined}
+                  onCheckedChange={(v) => updateSettings({ fullscreen_overlay: !v })}
+                />
+                <Label
+                  htmlFor="window-mode"
+                  className={`text-sm ${overlayActive ? "text-muted-foreground cursor-not-allowed" : "cursor-pointer"}`}
+                >
+                  {t("overlaySettings.windowMode")}
+                </Label>
               </div>
+
+              {/* 目标窗口（仅窗口模式时显示） */}
+              {!config.settings.fullscreen_overlay && (
+                <TargetWindowSelect
+                  value={profile?.target_window ?? ""}
+                  onChange={(v) => updateProfileTargetWindow(v === "__none__" ? "" : v)}
+                />
+              )}
+
+              {/* 开始/停止覆盖 */}
+              <div>
+                {overlayActive ? (
+                  <Button
+                    variant="destructive"
+                    className="w-full h-8 text-sm"
+                    onClick={handleStopOverlay}
+                  >
+                    ■ {t("config.stopOverlay")}
+                  </Button>
+                ) : (
+                  <Button
+                    className="w-full h-8 text-sm"
+                    onClick={handleStartOverlay}
+                    disabled={
+                      !config.settings.fullscreen_overlay && !profile?.target_window
+                    }
+                  >
+                    ▶ {t("config.startOverlay")}
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            {/* 开发者面板已移除（合并到设置窗口的「开发」Tab） */}
+
+            {/* 底部信息：版本号（纯文本，配置窗口无解锁彩蛋） */}
+            <div className="text-xs text-muted-foreground text-right select-none shrink-0">
+              Peregrine v{version || "..."}
             </div>
           </div>
         </div>
+      )}
 
-        <Separator className="shrink-0" />
-
-        {/* 中间样式配置：默认随窗口高度自适应，内容过多时才滚动 */}
-        <div className="flex-1 min-h-0 overflow-y-auto pr-1">
-          <StyleFields
-            crosshair={ch}
-            onChange={updateCrosshair}
-            disabled={!effectiveCompatible}
-          />
-        </div>
-
-        <Separator className="shrink-0" />
-
-        {/* 底部固定区：覆盖模式 + 目标窗口 + 开始/停止覆盖 */}
-        <div className="space-y-3 shrink-0">
-          {/* 窗口模式勾选（默认全屏，勾选切换为窗口模式）。覆盖层激活时禁止切换，避免状态不一致。 */}
-          <div className="flex items-center gap-2">
-            <Checkbox
-              id="window-mode"
-              checked={!config.settings.fullscreen_overlay}
-              disabled={overlayActive}
-              title={overlayActive ? t("overlay.windowModeBlockedHint") : undefined}
-              onCheckedChange={(v) => updateSettings({ fullscreen_overlay: !v })}
-            />
-            <Label
-              htmlFor="window-mode"
-              className={`text-sm ${overlayActive ? "text-muted-foreground cursor-not-allowed" : "cursor-pointer"}`}
-            >
-              {t("overlaySettings.windowMode")}
-            </Label>
-          </div>
-
-          {/* 目标窗口（仅窗口模式时显示） */}
-          {!config.settings.fullscreen_overlay && (
-            <TargetWindowSelect
-              value={profile?.target_window ?? ""}
-              onChange={(v) => updateProfileTargetWindow(v === "__none__" ? "" : v)}
-            />
-          )}
-
-          {/* 开始/停止覆盖 */}
-          <div>
-            {overlayActive ? (
-              <Button
-                variant="destructive"
-                className="w-full h-8 text-sm"
-                onClick={handleStopOverlay}
-              >
-                ■ {t("config.stopOverlay")}
-              </Button>
-            ) : (
-              <Button
-                className="w-full h-8 text-sm"
-                onClick={handleStartOverlay}
-                disabled={
-                  !config.settings.fullscreen_overlay && !profile?.target_window
-                }
-              >
-                ▶ {t("config.startOverlay")}
-              </Button>
-            )}
-          </div>
-        </div>
-
-        {/* 开发者面板已移除（合并到设置窗口的「开发」Tab） */}
-
-        {/* 底部信息：版本号（纯文本，配置窗口无解锁彩蛋） */}
-        <div className="text-xs text-muted-foreground text-right select-none shrink-0">
-          Peregrine v{version || "..."}
-        </div>
-      </div>
+      {/* ===== 全局对话框层（任务 6.1-6.5） =====
+          与编辑模式（单图层/多图层）解耦，两种模式下都正常挂载渲染。 */}
 
       {/* 自动切换确认对话框 */}
       {showAutoSwitchDialog && (
@@ -420,6 +422,6 @@ export default function ConfigApp() {
 
       {/* 更新下载进度 */}
       {updating && <UpdateProgress progress={updateProgress} />}
-    </div>
+    </>
   );
 }

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -48,7 +48,7 @@ export default function SettingsApp() {
       settings: { ...config.settings, auto_switch_on_overlay: value },
     };
     setConfig(newConfig);
-    updatePreferences({ auto_switch_on_overlay: value }).catch(console.error);
+    updatePreferences({ auto_switch_on_overlay: value }).catch(() => {});
   };
 
   // AboutTab 解锁成功后立即更新本地 config state（updatePreferences 已写盘 +
@@ -120,7 +120,7 @@ export default function SettingsApp() {
                     settings: { ...config.settings, hotkey_bindings: newBindings },
                   };
                   setConfig(newConfig);
-                  updatePreferences({ hotkey_bindings: newBindings }).catch(console.error);
+                  updatePreferences({ hotkey_bindings: newBindings }).catch(() => {});
                 }}
               />
             </CardContent>

--- a/src/components/LayerEditors.tsx
+++ b/src/components/LayerEditors.tsx
@@ -52,7 +52,11 @@ export function LayerStyleEditor({
         min={0}
         max={1}
         step={0.01}
-        unit="%"
+        format={(v) => Math.round(v * 100) + "%"}
+        parse={(text) => {
+          const n = parseFloat(text);
+          return Number.isFinite(n) ? n / 100 : 0;
+        }}
         disabled={layer.locked}
         onChange={(opacity) => update({ opacity })}
       />

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -10,6 +10,8 @@ import {
   updateLayer,
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { Trash2, Copy, ChevronUp, ChevronDown, Plus, Eye, EyeOff, Lock, Unlock } from "lucide-react";
 import { logAction } from "@/lib/actionLog";
 import { useI18n } from "@/lib/i18n";
@@ -392,6 +394,18 @@ function renderWidget(
         />
       );
     case "number":
+      // 位掩码字段（custom_orb.orb_positions / edge_arrows.positions_mask）：
+      // 渲染为 4 个 checkbox，提升多图层模式下的可操作性。
+      if (entry.bitmask) {
+        return (
+          <BitmaskField
+            label={entry.label}
+            value={typeof value === "number" ? value : 0}
+            disabled={disabled}
+            onChange={(v) => onChange(v)}
+          />
+        );
+      }
       return (
         <NumberField
           label={entry.label}
@@ -465,4 +479,52 @@ function renderWidget(
         </div>
       );
   }
+}
+
+/** 位掩码字段：把 4 位整数（1=top, 2=bottom, 4=left, 8=right）渲染为 4 个 checkbox。
+ *
+ * 用于 custom_orb.orb_positions、edge_arrows.positions_mask 等位掩码字段，
+ * 替代裸数字输入，避免用户手算位运算。
+ */
+function BitmaskField({
+  label,
+  value,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  disabled?: boolean;
+  onChange: (v: number) => void;
+}) {
+  const { t } = useI18n();
+  const items: { flag: number; key: string; label: string }[] = [
+    { flag: 0b0001, key: "top", label: t("fields.top") },
+    { flag: 0b0010, key: "bottom", label: t("fields.bottom") },
+    { flag: 0b0100, key: "left", label: t("fields.left") },
+    { flag: 0b1000, key: "right", label: t("fields.right") },
+  ];
+  const set = (flag: number, checked: boolean) => {
+    onChange(checked ? value | flag : value & ~flag);
+  };
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm">{label}</Label>
+      <div className="flex flex-wrap gap-4">
+        {items.map(({ flag, key, label: itemLabel }) => (
+          <div key={key} className="flex items-center gap-1">
+            <Checkbox
+              id={`bitmask-${key}`}
+              checked={(value & flag) !== 0}
+              disabled={disabled}
+              onCheckedChange={(v) => set(flag, !!v)}
+            />
+            <Label htmlFor={`bitmask-${key}`} className="text-sm">
+              {itemLabel}
+            </Label>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -453,13 +453,20 @@ function renderWidget(
       // 任务 9.7：物料 schema 标记 coming_soon 的 select 控件禁用，
       // 并在 label 后追加「（开发中）」提示（random_orb.mode 等）。
       const comingSoon = entry.coming_soon === true;
+      // 原始 schema option value 可能是数字（corner_dots.count）或字符串（mode）。
+      // SelectField 只接受 string，但回传给 onChange 时需按原始类型还原，
+      // 否则 Rhai 侧 `params.count >= 6` 会因类型不匹配而失败（"6" vs 6）。
+      const originalOptions = entry.options ?? [];
       return (
         <SelectField
           label={comingSoon ? `${entry.label}（开发中）` : entry.label}
           value={String(value ?? "")}
           options={options}
           disabled={disabled || comingSoon}
-          onChange={(v) => onChange(v)}
+          onChange={(v) => {
+            const matched = originalOptions.find((opt) => String(opt.value) === v);
+            onChange(matched ? matched.value : v);
+          }}
         />
       );
     }

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -58,7 +58,9 @@ export function LayerPanel({
             .filter((m) => m.id !== "builtin.custom_image"),
         ),
       )
-      .catch(console.error);
+      .catch(() => {
+        // listMaterials 失败由 invoke 包装 toast 提示；这里不阻塞 UI。
+      });
   }, []);
 
   const handleAdd = async (materialId: string, name: string) => {
@@ -434,12 +436,15 @@ function renderWidget(
         value: String(opt.value),
         label: opt.label,
       }));
+      // 任务 9.7：物料 schema 标记 coming_soon 的 select 控件禁用，
+      // 并在 label 后追加「（开发中）」提示（random_orb.mode 等）。
+      const comingSoon = entry.coming_soon === true;
       return (
         <SelectField
-          label={entry.label}
+          label={comingSoon ? `${entry.label}（开发中）` : entry.label}
           value={String(value ?? "")}
           options={options}
-          disabled={disabled}
+          disabled={disabled || comingSoon}
           onChange={(v) => onChange(v)}
         />
       );

--- a/src/components/LayersEditor.tsx
+++ b/src/components/LayersEditor.tsx
@@ -11,7 +11,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { Layer, MaterialInfo, AppConfig } from "@/types/config";
-import { listLayers, listMaterials, saveConfig } from "@/lib/api";
+import {
+  listLayers,
+  listMaterials,
+  updateProfileField,
+  getConfig,
+} from "@/lib/api";
 import { listen } from "@tauri-apps/api/event";
 import { Preview } from "@/components/Preview";
 import { LayerPanel, MaterialParamControls } from "@/components/LayerPanel";
@@ -116,11 +121,21 @@ export function LayersEditor({
     refresh();
   }, [refresh, refreshKey]);
 
+  // 任务 5.2：监听 peregrine:layers-changed 事件时除 refresh 外，
+  // 同时 getConfig() → onConfigChange 同步整个 config，作为 patch API 的兜底
+  // （防止前端内存态 config 在图层操作后过期）。
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     listen("peregrine:layers-changed", () => {
       logAction("layers-changed event");
       refresh();
+      // 拉取后端最新整个 config 同步给 ConfigApp 的 setConfig，
+      // 确保前端 config.profiles.X.layers 与后端一致。
+      getConfig()
+        .then((cfg) => onConfigChange(cfg))
+        .catch(() => {
+          // getConfig 失败不影响图层列表刷新；invoke 包装会 toast 提示。
+        });
       setRefreshKey((n) => n + 1);
     }).then((un) => {
       unlisten = un;
@@ -128,7 +143,7 @@ export function LayersEditor({
     return () => {
       if (unlisten) unlisten();
     };
-  }, [refresh]);
+  }, [refresh, onConfigChange]);
 
   const triggerPreviewRefresh = () => setRefreshKey((n) => n + 1);
 
@@ -147,6 +162,9 @@ export function LayersEditor({
 
   const updateTargetWindow = (targetWindow: string) => {
     if (!profile) return;
+    // 任务 5.1：改走 updateProfileField patch API，不再调 saveConfig 全量覆盖后端。
+    // 这样后端 profile.layers 不会被前端内存态的旧 layers 覆盖（根治配置丢失）。
+    // 前端本地 config 也同步更新，保持 UI 一致。
     const newConfig: AppConfig = {
       ...config,
       profiles: {
@@ -158,7 +176,12 @@ export function LayersEditor({
       },
     };
     onConfigChange(newConfig);
-    saveConfig(newConfig).catch(console.error);
+    updateProfileField(config.active_profile, {
+      kind: "target_window",
+      value: targetWindow,
+    }).catch(() => {
+      // invoke 包装负责 toast；本地 config 已乐观更新，后端失败时下次 layers-changed 事件会回滚。
+    });
   };
 
   return (
@@ -374,9 +397,9 @@ async function updateLayerName(layerId: string, name: string, onChanged: () => v
   try {
     await updateLayer(layerId, { name });
     onChanged();
-  } catch (err) {
-    // 图层可能已被删除（在途请求晚到），仅记录不抛出未捕获 Promise。
-    console.error("updateLayerName failed:", err);
+  } catch {
+    // 图层可能已被删除（在途请求晚到）；invoke 包装已 toast 提示，
+    // 这里不再重复 console.error。
   }
 }
 

--- a/src/components/StyleFields.tsx
+++ b/src/components/StyleFields.tsx
@@ -118,14 +118,7 @@ function CornerDotsFields({ crosshair, onChange }: StyleFieldsProps) {
         onChange={(v) => onChange({ style: v as CrosshairStyle })}
       />
       <SliderField label={t("fields.offset")} value={crosshair.offset} min={0} max={1920} onChange={(v) => onChange({ offset: v })} />
-      <SliderField
-        label={crosshair.radius > 0 ? t("fields.radius") : t("fields.radiusAuto")}
-        value={crosshair.radius}
-        min={0}
-        max={500}
-        onChange={(v) => onChange({ radius: v })}
-      />
-      <SliderField label={t("fields.lineWidthAuto")} value={crosshair.thickness} min={0.5} max={50} step={0.5} onChange={(v) => onChange({ thickness: v })} />
+      <SliderField label={t("fields.radius")} value={crosshair.radius} min={1} max={500} step={0.5} onChange={(v) => onChange({ radius: v })} />
     </div>
   );
 }

--- a/src/components/StyleFields.tsx
+++ b/src/components/StyleFields.tsx
@@ -3,7 +3,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useI18n } from "@/lib/i18n";
 import { pickImagePath } from "@/lib/api";
-import type { Crosshair, Anchor, RingStyle, BorderFrameStyle, GridAlignment } from "@/types/config";
+import type { Crosshair, CrosshairStyle, Anchor, RingStyle, BorderFrameStyle, GridAlignment } from "@/types/config";
 import { SliderField } from "@/components/fields/SliderField";
 import { SelectField } from "@/components/fields/SelectField";
 
@@ -64,16 +64,15 @@ function EdgeRectFields({ crosshair, onChange }: StyleFieldsProps) {
   const { t } = useI18n();
   return (
     <div className="space-y-2">
-      <SliderField label={t("fields.width")} value={crosshair.size} min={10} max={400} onChange={(v) => onChange({ size: v })} />
-      <SliderField label={t("fields.height")} value={crosshair.secondary_size} min={10} max={300} onChange={(v) => onChange({ secondary_size: v })} />
-      <SliderField label={t("fields.cornerRadius")} value={crosshair.corner_radius} min={0} max={60} onChange={(v) => onChange({ corner_radius: v })} />
+      <SliderField label={t("fields.width")} value={crosshair.size} min={10} max={1920} onChange={(v) => onChange({ size: v })} />
+      <SliderField label={t("fields.height")} value={crosshair.secondary_size} min={4} max={1920} onChange={(v) => onChange({ secondary_size: v })} />
       <SelectField
         label={t("fields.anchor")}
         value={crosshair.anchor}
         options={ANCHORS.map((a) => ({ value: a, label: t(`anchors.${a}`) }))}
         onChange={(v) => onChange({ anchor: v as Anchor })}
       />
-      <SliderField label={t("fields.margin")} value={crosshair.margin} min={0} max={200} onChange={(v) => onChange({ margin: v })} />
+      <SliderField label={t("fields.margin")} value={crosshair.margin} min={0} max={1920} onChange={(v) => onChange({ margin: v })} />
     </div>
   );
 }
@@ -83,9 +82,9 @@ function CrossFields({ crosshair, onChange }: StyleFieldsProps) {
   const { t } = useI18n();
   return (
     <div className="space-y-2">
-      <SliderField label={t("fields.armLength")} value={crosshair.size} min={5} max={200} onChange={(v) => onChange({ size: v })} />
-      <SliderField label={t("fields.lineWidth")} value={crosshair.thickness} min={1} max={20} onChange={(v) => onChange({ thickness: v })} />
-      <SliderField label={t("fields.centerGap")} value={crosshair.gap} min={0} max={50} onChange={(v) => onChange({ gap: v })} />
+      <SliderField label={t("fields.armLength")} value={crosshair.size} min={1} max={1920} onChange={(v) => onChange({ size: v })} />
+      <SliderField label={t("fields.lineWidth")} value={crosshair.thickness} min={0.5} max={50} step={0.5} onChange={(v) => onChange({ thickness: v })} />
+      <SliderField label={t("fields.centerGap")} value={crosshair.gap} min={0} max={200} onChange={(v) => onChange({ gap: v })} />
     </div>
   );
 }
@@ -95,7 +94,7 @@ function LargeCrossFields({ crosshair, onChange }: StyleFieldsProps) {
   const { t } = useI18n();
   return (
     <div className="space-y-2">
-      <SliderField label={t("fields.lineWidth")} value={crosshair.thickness} min={1} max={30} onChange={(v) => onChange({ thickness: v })} />
+      <SliderField label={t("fields.lineWidth")} value={crosshair.thickness} min={0.5} max={50} step={0.5} onChange={(v) => onChange({ thickness: v })} />
     </div>
   );
 }
@@ -103,17 +102,30 @@ function LargeCrossFields({ crosshair, onChange }: StyleFieldsProps) {
 /** 定位球（4/6/8）。 */
 function CornerDotsFields({ crosshair, onChange }: StyleFieldsProps) {
   const { t } = useI18n();
+  // 点数切换：style 枚举里编码了 4/6/8，提供独立 select 让用户在字段面板内直接切换，
+  // 不必回到顶部 style 下拉。切回时需要同步 crosshair.style。
+  const countOptions = [
+    { value: "corner_dots4", label: t("cornerDotsCount.4") },
+    { value: "corner_dots6", label: t("cornerDotsCount.6") },
+    { value: "corner_dots8", label: t("cornerDotsCount.8") },
+  ];
   return (
     <div className="space-y-2">
-      <SliderField label={t("fields.offset")} value={crosshair.offset} min={0} max={200} onChange={(v) => onChange({ offset: v })} />
+      <SelectField
+        label={t("fields.dotCount")}
+        value={crosshair.style}
+        options={countOptions}
+        onChange={(v) => onChange({ style: v as CrosshairStyle })}
+      />
+      <SliderField label={t("fields.offset")} value={crosshair.offset} min={0} max={1920} onChange={(v) => onChange({ offset: v })} />
       <SliderField
         label={crosshair.radius > 0 ? t("fields.radius") : t("fields.radiusAuto")}
         value={crosshair.radius}
         min={0}
-        max={80}
+        max={500}
         onChange={(v) => onChange({ radius: v })}
       />
-      <SliderField label={t("fields.lineWidthAuto")} value={crosshair.thickness} min={1} max={20} onChange={(v) => onChange({ thickness: v })} />
+      <SliderField label={t("fields.lineWidthAuto")} value={crosshair.thickness} min={0.5} max={50} step={0.5} onChange={(v) => onChange({ thickness: v })} />
     </div>
   );
 }
@@ -124,7 +136,7 @@ function RingFields({ crosshair, onChange }: StyleFieldsProps) {
   return (
     <div className="space-y-2">
       <SliderField label={t("fields.ringRadiusPct")} value={crosshair.ring_radius_pct} min={0.03} max={0.08} step={0.001} onChange={(v) => onChange({ ring_radius_pct: v })} />
-      <SliderField label={t("fields.lineWidth")} value={crosshair.thickness} min={1} max={3} onChange={(v) => onChange({ thickness: v })} />
+      <SliderField label={t("fields.lineWidth")} value={crosshair.thickness} min={0.5} max={50} step={0.5} onChange={(v) => onChange({ thickness: v })} />
       <SelectField
         label={t("fields.ringStyle")}
         value={crosshair.ring_style}
@@ -141,8 +153,8 @@ function CustomOrbFields({ crosshair, onChange }: StyleFieldsProps) {
   return (
     <div className="space-y-2">
       <div className="grid grid-cols-2 gap-3">
-        <SliderField label={t("fields.radius")} value={crosshair.radius} min={4} max={12} onChange={(v) => onChange({ radius: v })} />
-        <SliderField label={t("fields.offset")} value={crosshair.offset} min={10} max={200} onChange={(v) => onChange({ offset: v })} />
+        <SliderField label={t("fields.radius")} value={crosshair.radius} min={1} max={500} step={0.5} onChange={(v) => onChange({ radius: v })} />
+        <SliderField label={t("fields.offset")} value={crosshair.offset} min={0} max={1920} onChange={(v) => onChange({ offset: v })} />
         <SliderField label={t("fields.countTop")} value={crosshair.custom_orb_top_count} min={1} max={10} step={1} onChange={(v) => onChange({ custom_orb_top_count: v })} />
         <SliderField label={t("fields.countBottom")} value={crosshair.custom_orb_bottom_count} min={1} max={10} step={1} onChange={(v) => onChange({ custom_orb_bottom_count: v })} />
         <SliderField label={t("fields.countLeft")} value={crosshair.custom_orb_left_count} min={1} max={10} step={1} onChange={(v) => onChange({ custom_orb_left_count: v })} />
@@ -158,11 +170,11 @@ function RandomOrbFields({ crosshair, onChange }: StyleFieldsProps) {
   const { t } = useI18n();
   return (
     <div className="space-y-2">
-      <SliderField label={t("fields.perEdgeCount")} value={crosshair.random_orb_count} min={1} max={10} step={1} onChange={(v) => onChange({ random_orb_count: v })} />
-      <SliderField label={t("fields.offset")} value={crosshair.random_orb_offset} min={0} max={300} onChange={(v) => onChange({ random_orb_offset: v })} />
-      <SliderField label={t("fields.positionJitter")} value={crosshair.random_orb_jitter} min={0} max={200} onChange={(v) => onChange({ random_orb_jitter: v })} />
-      <SliderField label={t("fields.radiusMin")} value={crosshair.random_radius_min} min={4} max={12} onChange={(v) => onChange({ random_radius_min: v })} />
-      <SliderField label={t("fields.radiusMax")} value={crosshair.random_radius_max} min={4} max={12} onChange={(v) => onChange({ random_radius_max: v })} />
+      <SliderField label={t("fields.perEdgeCount")} value={crosshair.random_orb_count} min={1} max={20} step={1} onChange={(v) => onChange({ random_orb_count: v })} />
+      <SliderField label={t("fields.offset")} value={crosshair.random_orb_offset} min={0} max={1920} onChange={(v) => onChange({ random_orb_offset: v })} />
+      <SliderField label={t("fields.positionJitter")} value={crosshair.random_orb_jitter} min={0} max={1920} onChange={(v) => onChange({ random_orb_jitter: v })} />
+      <SliderField label={t("fields.radiusMin")} value={crosshair.random_radius_min} min={1} max={500} step={0.5} onChange={(v) => onChange({ random_radius_min: v })} />
+      <SliderField label={t("fields.radiusMax")} value={crosshair.random_radius_max} min={1} max={500} step={0.5} onChange={(v) => onChange({ random_radius_max: v })} />
     </div>
   );
 }
@@ -172,8 +184,8 @@ function BorderFrameFields({ crosshair, onChange }: StyleFieldsProps) {
   const { t } = useI18n();
   return (
     <div className="space-y-2">
-      <SliderField label={t("fields.barHeight")} value={crosshair.thickness} min={1} max={20} onChange={(v) => onChange({ thickness: v })} />
-      <SliderField label={t("fields.offset")} value={crosshair.offset} min={0} max={100} onChange={(v) => onChange({ offset: v })} />
+      <SliderField label={t("fields.barHeight")} value={crosshair.thickness} min={1} max={50} onChange={(v) => onChange({ thickness: v })} />
+      <SliderField label={t("fields.offset")} value={crosshair.offset} min={0} max={1920} onChange={(v) => onChange({ offset: v })} />
       <SelectField
         label={t("fields.borderStyle")}
         value={crosshair.border_frame_style}
@@ -189,21 +201,21 @@ function EdgeArrowsFields({ crosshair, onChange }: StyleFieldsProps) {
   const { t } = useI18n();
   return (
     <div className="space-y-2">
-      <SliderField label={t("fields.arrowSize")} value={crosshair.size} min={4} max={60} step={1} onChange={(v) => onChange({ size: v })} />
-      <SliderField label={t("fields.arrowWidth")} value={crosshair.arrow_width} min={0} max={72} step={1} onChange={(v) => onChange({ arrow_width: v })} />
+      <SliderField label={t("fields.arrowSize")} value={crosshair.size} min={4} max={400} step={1} onChange={(v) => onChange({ size: v })} />
+      <SliderField label={t("fields.arrowWidth")} value={crosshair.arrow_width} min={0} max={200} step={1} onChange={(v) => onChange({ arrow_width: v })} />
       <div className="flex items-center gap-3">
         <Checkbox id="tail_per_edge" checked={crosshair.arrow_tail_per_edge} onCheckedChange={(v) => onChange({ arrow_tail_per_edge: !!v })} />
         <Label htmlFor="tail_per_edge" className="text-sm">{t("fields.tailPerEdge")}</Label>
       </div>
       {crosshair.arrow_tail_per_edge ? (
         <div className="grid grid-cols-2 gap-3">
-          <SliderField label={t("fields.tailTop")} value={crosshair.arrow_tail_top} min={0} max={500} step={1} onChange={(v) => onChange({ arrow_tail_top: v })} />
-          <SliderField label={t("fields.tailBottom")} value={crosshair.arrow_tail_bottom} min={0} max={500} step={1} onChange={(v) => onChange({ arrow_tail_bottom: v })} />
-          <SliderField label={t("fields.tailLeft")} value={crosshair.arrow_tail_left} min={0} max={500} step={1} onChange={(v) => onChange({ arrow_tail_left: v })} />
-          <SliderField label={t("fields.tailRight")} value={crosshair.arrow_tail_right} min={0} max={500} step={1} onChange={(v) => onChange({ arrow_tail_right: v })} />
+          <SliderField label={t("fields.tailTop")} value={crosshair.arrow_tail_top} min={0} max={1920} step={1} onChange={(v) => onChange({ arrow_tail_top: v })} />
+          <SliderField label={t("fields.tailBottom")} value={crosshair.arrow_tail_bottom} min={0} max={1920} step={1} onChange={(v) => onChange({ arrow_tail_bottom: v })} />
+          <SliderField label={t("fields.tailLeft")} value={crosshair.arrow_tail_left} min={0} max={1920} step={1} onChange={(v) => onChange({ arrow_tail_left: v })} />
+          <SliderField label={t("fields.tailRight")} value={crosshair.arrow_tail_right} min={0} max={1920} step={1} onChange={(v) => onChange({ arrow_tail_right: v })} />
         </div>
       ) : (
-        <SliderField label={t("fields.tailLength")} value={crosshair.arrow_distance} min={0} max={500} step={1} onChange={(v) => onChange({ arrow_distance: v })} />
+        <SliderField label={t("fields.tailLength")} value={crosshair.arrow_distance} min={0} max={1920} step={1} onChange={(v) => onChange({ arrow_distance: v })} />
       )}
       <OrbPositionCheck crosshair={crosshair} onChange={onChange} />
     </div>
@@ -215,8 +227,8 @@ function GridFields({ crosshair, onChange }: StyleFieldsProps) {
   const { t } = useI18n();
   return (
     <div className="space-y-2">
-      <SliderField label={t("fields.gridSize")} value={crosshair.grid_size ?? 80} min={10} max={500} step={5} onChange={(v) => onChange({ grid_size: v })} />
-      <SliderField label={t("fields.lineWidth")} value={crosshair.thickness} min={1} max={20} onChange={(v) => onChange({ thickness: v })} />
+      <SliderField label={t("fields.gridSize")} value={crosshair.grid_size ?? 80} min={10} max={1920} step={1} onChange={(v) => onChange({ grid_size: v })} />
+      <SliderField label={t("fields.lineWidth")} value={crosshair.thickness} min={0.5} max={50} step={0.5} onChange={(v) => onChange({ thickness: v })} />
       <SelectField
         label={t("fields.gridAlignment")}
         value={crosshair.grid_alignment ?? "center"}
@@ -250,9 +262,9 @@ function CustomImageFields({ crosshair, onChange }: StyleFieldsProps) {
           <Button variant="secondary" onClick={handlePick} className="h-8 text-sm px-2">{t("fields.browse")}</Button>
         </div>
       </div>
-      <SliderField label={t("fields.imageScale")} value={crosshair.image_scale} min={0.1} max={5} step={0.1} onChange={(v) => onChange({ image_scale: v })} />
-      <SliderField label={t("fields.imageOffsetX")} value={crosshair.image_offset_x} min={-500} max={500} onChange={(v) => onChange({ image_offset_x: v })} />
-      <SliderField label={t("fields.imageOffsetY")} value={crosshair.image_offset_y} min={-500} max={500} onChange={(v) => onChange({ image_offset_y: v })} />
+      <SliderField label={t("fields.imageScale")} value={crosshair.image_scale} min={0.1} max={50} step={0.1} onChange={(v) => onChange({ image_scale: v })} />
+      <SliderField label={t("fields.imageOffsetX")} value={crosshair.image_offset_x} min={-1920} max={1920} onChange={(v) => onChange({ image_offset_x: v })} />
+      <SliderField label={t("fields.imageOffsetY")} value={crosshair.image_offset_y} min={-1920} max={1920} onChange={(v) => onChange({ image_offset_y: v })} />
     </div>
   );
 }

--- a/src/components/config/TargetWindowSelect.tsx
+++ b/src/components/config/TargetWindowSelect.tsx
@@ -21,7 +21,7 @@ export function TargetWindowSelect({ value, onChange }: TargetWindowSelectProps)
   const [windows, setWindows] = useState<string[]>([]);
 
   const refreshWindows = () => {
-    listWindowTitles().then(setWindows).catch(console.error);
+    listWindowTitles().then(setWindows).catch(() => {});
   };
 
   useEffect(() => {

--- a/src/components/fields/ImagePathField.tsx
+++ b/src/components/fields/ImagePathField.tsx
@@ -1,6 +1,6 @@
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import { invoke } from "@tauri-apps/api/core";
+import { pickImagePath } from "@/lib/api";
 import { useI18n } from "@/lib/i18n";
 
 /** 图片路径字段组件 Props。 */
@@ -47,8 +47,12 @@ export function ImagePathField({
           variant="outline"
           disabled={disabled}
           onClick={async () => {
-            const path = await invoke<string | null>("pick_image_path");
-            if (path) onChange(path);
+            try {
+              const path = await pickImagePath();
+              if (path) onChange(path);
+            } catch {
+              // 用户取消或调用失败，invoke 包装负责 toast。
+            }
           }}
         >
           {t("fields.browse")}

--- a/src/components/fields/SliderField.tsx
+++ b/src/components/fields/SliderField.tsx
@@ -5,7 +5,7 @@ import { Label } from "@/components/ui/label";
 interface SliderFieldProps {
   /** 字段标签文本，渲染在第一行左侧。 */
   label: string;
-  /** 当前数值。 */
+  /** 当前数值（真实值，例如透明度 0.5）。 */
   value: number;
   /** 最小值，默认 0。 */
   min?: number;
@@ -18,15 +18,24 @@ interface SliderFieldProps {
    * 传入 `format` 时本字段被忽略（format 负责完整格式化）。
    */
   unit?: string;
-  /** 可选的数值格式化回调，用于自定义展示（如透明度 0.5 → "50%"）。
+  /** 可选的数值显示格式化回调（如透明度 0.5 → "50%"）。
    *
-   * 传入时数值输入框只读展示 `format(value)` 的返回值，且 `unit` 后缀被隐藏。
-   * 未传入时保持原有行为（显示原始 value + 可选 unit）。
+   * 与 `parse` 配对使用时，数值输入框仍可编辑：
+   * - 展示时调用 `format(value)` 渲染（如 0.5 → "50%"）；
+   * - 键入时调用 `parse(text)` 反解为真实值（如 "50" → 0.5）。
+   *
+   * 未传入 `parse` 时退化为只读展示（旧行为，向后兼容）。
    */
   format?: (v: number) => string;
+  /** 可选的反解析回调，与 `format` 配对。
+   *
+   * 传入时数值输入框在 format 模式下也可编辑；键入文本由本回调转回真实值。
+   * 未传入而 `format` 存在时，输入框只读。
+   */
+  parse?: (text: string) => number;
   /** 是否禁用控件。 */
   disabled?: boolean;
-  /** 数值变化回调，参数为新值。 */
+  /** 数值变化回调，参数为真实值（如透明度 0.5）。 */
   onChange: (v: number) => void;
 }
 
@@ -36,8 +45,9 @@ interface SliderFieldProps {
  * - 拖拽滑块 → 数值输入框同步更新；
  * - 键入数值 → 滑块位置同步更新（Radix 自动 clamp 到 min/max）。
  *
- * 传入 `format` 时数值输入框变为只读展示（用 format 函数格式化），
- * `unit` 后缀被隐藏；此时用户仍可通过滑块调整值。
+ * - 不传 `format`：显示原始 value + 可选 unit，input 可编辑。
+ * - 传 `format` 且传 `parse`：input 显示 `format(value)`（如 "50%"），键入由 parse 转回真实值。
+ * - 传 `format` 但不传 `parse`：input 只读展示 `format(value)`（旧行为）。
  *
  * 输入框解析失败时 fallback 到 0。
  */
@@ -49,40 +59,61 @@ export function SliderField({
   step = 1,
   unit,
   format,
+  parse,
   disabled,
   onChange,
 }: SliderFieldProps) {
+  // format + parse 双传：可编辑，显示与键入都做转换。
+  const editableFormatted = format !== undefined && parse !== undefined;
+  // 仅 format 不传 parse：只读。
+  const readOnlyFormatted = format !== undefined && parse === undefined;
+
+  // 处理键入：format 模式下剥离非数字字符后用 parse 转回真实值，
+  // 普通模式直接 parseFloat。结果 clamp 到 [min, max]，避免越界值传给后端。
+  const handleInput = (raw: string) => {
+    if (raw.trim() === "") {
+      onChange(min);
+      return;
+    }
+    let num: number;
+    if (editableFormatted) {
+      // 容忍用户键入的 "%" 等后缀：剥离非数字字符（保留小数点与负号）。
+      const cleaned = raw.replace(/[^0-9.\-]/g, "");
+      num = parse!(cleaned);
+    } else {
+      num = parseFloat(raw);
+    }
+    if (!Number.isFinite(num)) {
+      onChange(min);
+      return;
+    }
+    // clamp 到 [min, max]，避免键入越界值（如 opacity 输 150 → clamp 到 100% → 1.0）。
+    onChange(Math.min(max, Math.max(min, num)));
+  };
+
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-2">
         <Label className="text-sm">{label}</Label>
         <div className="flex items-center gap-0.5">
-          {format ? (
-            // format 模式：只读展示格式化后的值（如 "50%"），隐藏 unit。
+          {readOnlyFormatted ? (
+            // 只读 format 模式（未传 parse）：仅展示，不可编辑。
             <span className="text-sm text-muted-foreground w-16 text-right">
-              {format(value)}
+              {format!(value)}
             </span>
           ) : (
             <>
               <input
-                type="number"
-                value={value}
-                min={min}
-                max={max}
-                step={step}
+                type="text"
+                inputMode="decimal"
+                value={editableFormatted ? format!(value) : value}
                 disabled={disabled}
-                onChange={(e) => {
-                  const raw = e.target.value;
-                  if (raw.trim() === "") {
-                    onChange(0);
-                    return;
-                  }
-                  const num = parseFloat(raw);
-                  onChange(Number.isFinite(num) ? num : 0);
-                }}
+                onChange={(e) => handleInput(e.target.value)}
                 className="w-16 text-right text-sm bg-transparent border-b border-transparent focus:border-b focus:outline-none cursor-text"
               />
-              {unit && <span className="text-xs text-muted-foreground">{unit}</span>}
+              {!format && unit && (
+                <span className="text-xs text-muted-foreground">{unit}</span>
+              )}
             </>
           )}
         </div>

--- a/src/components/fields/SliderField.tsx
+++ b/src/components/fields/SliderField.tsx
@@ -13,8 +13,17 @@ interface SliderFieldProps {
   max?: number;
   /** 步进值，默认 1。 */
   step?: number;
-  /** 可选单位后缀（如 "%" / "x" / "°"），显示在数值输入框右侧。 */
+  /** 可选单位后缀（如 "%" / "x" / "°"），显示在数值输入框右侧。
+   *
+   * 传入 `format` 时本字段被忽略（format 负责完整格式化）。
+   */
   unit?: string;
+  /** 可选的数值格式化回调，用于自定义展示（如透明度 0.5 → "50%"）。
+   *
+   * 传入时数值输入框只读展示 `format(value)` 的返回值，且 `unit` 后缀被隐藏。
+   * 未传入时保持原有行为（显示原始 value + 可选 unit）。
+   */
+  format?: (v: number) => string;
   /** 是否禁用控件。 */
   disabled?: boolean;
   /** 数值变化回调，参数为新值。 */
@@ -27,6 +36,9 @@ interface SliderFieldProps {
  * - 拖拽滑块 → 数值输入框同步更新；
  * - 键入数值 → 滑块位置同步更新（Radix 自动 clamp 到 min/max）。
  *
+ * 传入 `format` 时数值输入框变为只读展示（用 format 函数格式化），
+ * `unit` 后缀被隐藏；此时用户仍可通过滑块调整值。
+ *
  * 输入框解析失败时 fallback 到 0。
  */
 export function SliderField({
@@ -36,6 +48,7 @@ export function SliderField({
   max = 100,
   step = 1,
   unit,
+  format,
   disabled,
   onChange,
 }: SliderFieldProps) {
@@ -44,25 +57,34 @@ export function SliderField({
       <div className="flex items-center justify-between gap-2">
         <Label className="text-sm">{label}</Label>
         <div className="flex items-center gap-0.5">
-          <input
-            type="number"
-            value={value}
-            min={min}
-            max={max}
-            step={step}
-            disabled={disabled}
-            onChange={(e) => {
-              const raw = e.target.value;
-              if (raw.trim() === "") {
-                onChange(0);
-                return;
-              }
-              const num = parseFloat(raw);
-              onChange(Number.isFinite(num) ? num : 0);
-            }}
-            className="w-16 text-right text-sm bg-transparent border-b border-transparent focus:border-b focus:outline-none cursor-text"
-          />
-          {unit && <span className="text-xs text-muted-foreground">{unit}</span>}
+          {format ? (
+            // format 模式：只读展示格式化后的值（如 "50%"），隐藏 unit。
+            <span className="text-sm text-muted-foreground w-16 text-right">
+              {format(value)}
+            </span>
+          ) : (
+            <>
+              <input
+                type="number"
+                value={value}
+                min={min}
+                max={max}
+                step={step}
+                disabled={disabled}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  if (raw.trim() === "") {
+                    onChange(0);
+                    return;
+                  }
+                  const num = parseFloat(raw);
+                  onChange(Number.isFinite(num) ? num : 0);
+                }}
+                className="w-16 text-right text-sm bg-transparent border-b border-transparent focus:border-b focus:outline-none cursor-text"
+              />
+              {unit && <span className="text-xs text-muted-foreground">{unit}</span>}
+            </>
+          )}
         </div>
       </div>
       <Slider

--- a/src/components/settings/AboutTab.tsx
+++ b/src/components/settings/AboutTab.tsx
@@ -35,7 +35,7 @@ export function AboutTab({ version, developerMode, onDeveloperModeChange }: Abou
       setClickCount(0);
       setJustUnlocked(true);
       setTimeout(() => setJustUnlocked(false), 3000);
-      updatePreferences({ developer_mode: true }).catch(console.error);
+      updatePreferences({ developer_mode: true }).catch(() => {});
       onDeveloperModeChange(true);
     }
     return () => clearTimeout(timer);

--- a/src/components/settings/GeneralTab.tsx
+++ b/src/components/settings/GeneralTab.tsx
@@ -49,7 +49,7 @@ export function GeneralTab({ config, locale, setConfig, setLocale }: GeneralTabP
                 settings: { ...config.settings, cn_mirror: false },
               };
               setConfig(newConfig);
-              updatePreferences({ cn_mirror: false }).catch(console.error);
+              updatePreferences({ cn_mirror: false }).catch(() => {});
             }
           }}
         >

--- a/src/components/settings/OverlayTab.tsx
+++ b/src/components/settings/OverlayTab.tsx
@@ -37,7 +37,7 @@ export function OverlayTab({
       settings: { ...config.settings, [key]: value },
     };
     setConfig(newConfig);
-    updatePreferences({ [key]: value } as Partial<AppConfig["settings"]>).catch(console.error);
+    updatePreferences({ [key]: value } as Partial<AppConfig["settings"]>).catch(() => {});
   };
 
   return (

--- a/src/components/settings/UpdateTab.tsx
+++ b/src/components/settings/UpdateTab.tsx
@@ -58,7 +58,7 @@ export function UpdateTab({
       settings: { ...config.settings, [key]: value },
     };
     setConfig(newConfig);
-    updatePreferences({ [key]: value } as Partial<AppConfig["settings"]>).catch(console.error);
+    updatePreferences({ [key]: value } as Partial<AppConfig["settings"]>).catch(() => {});
   };
 
   const handleCheckUpdate = async () => {

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -8,7 +8,7 @@ export function useConfig() {
   useEffect(() => {
     getConfig()
       .then(setConfig)
-      .catch(console.error);
+      .catch(() => {});
   }, []);
 
   return { config, setConfig };

--- a/src/hooks/useConfigAppState.ts
+++ b/src/hooks/useConfigAppState.ts
@@ -56,7 +56,9 @@ export function useConfigAppState() {
           setLayersMode(true);
         }
       })
-      .catch(console.error)
+      .catch(() => {
+        // getConfig 失败由 invoke 包装 toast 提示；loading 状态仍要解除。
+      })
       .finally(() => setLoading(false));
     refreshWindows();
     refreshProfiles();
@@ -68,11 +70,12 @@ export function useConfigAppState() {
   useInitMirror();
 
   const refreshWindows = () => {
-    listWindowTitles().then(setWindows).catch(console.error);
+    // 列表加载失败可忽略（invoke 包装会 toast）。
+    listWindowTitles().then(setWindows).catch(() => {});
   };
 
   const refreshProfiles = () => {
-    listProfiles().then(setProfiles).catch(console.error);
+    listProfiles().then(setProfiles).catch(() => {});
   };
 
   /** 切换 active profile：调后端后重新拉取完整配置与 profile 列表。 */

--- a/src/hooks/useConfigSave.ts
+++ b/src/hooks/useConfigSave.ts
@@ -21,7 +21,9 @@ export function useConfigSave(
   const debouncedSave = useCallback((cfg: AppConfig) => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
-      saveConfig(cfg).catch(console.error);
+      // saveConfig 失败时 invoke 包装负责 toast 提示；
+      // 防抖期间多次修改，后端失败可由下次 saveConfig 或 layers-changed 事件回滚。
+      saveConfig(cfg).catch(() => {});
     }, 300);
   }, []);
 

--- a/src/hooks/useOverlayActions.ts
+++ b/src/hooks/useOverlayActions.ts
@@ -16,7 +16,8 @@ export function useOverlayActions(
   const profile = config?.profiles[config.active_profile];
 
   const hideAndSwitch = useCallback(async (targetWindow: string) => {
-    focusTargetWindow(targetWindow).catch(console.error);
+    // focusTargetWindow 失败不阻塞隐藏窗口流程；invoke 包装会 toast 提示。
+    focusTargetWindow(targetWindow).catch(() => {});
     await getCurrentWebviewWindow().destroy();
   }, []);
 
@@ -37,8 +38,8 @@ export function useOverlayActions(
       } else {
         onAskAutoSwitch();
       }
-    } catch (e) {
-      console.error(e);
+    } catch {
+      // invoke 包装负责 toast；这里不再 console.error。
     }
   }, [
     config?.settings.fullscreen_overlay,
@@ -53,16 +54,17 @@ export function useOverlayActions(
     try {
       await stopOverlay();
       setOverlayActive(false);
-    } catch (e) {
-      console.error(e);
+    } catch {
+      // invoke 包装负责 toast。
     }
   }, [setOverlayActive]);
 
   const saveAutoSwitchPreference = useCallback(
     (value: "yes" | "no", targetWindow?: string) => {
-      updatePreferences({ auto_switch_on_overlay: value }).catch(console.error);
+      // updatePreferences 失败由 invoke 包装 toast；这里不阻塞 hideAndSwitch。
+      updatePreferences({ auto_switch_on_overlay: value }).catch(() => {});
       if (targetWindow) {
-        hideAndSwitch(targetWindow).catch(console.error);
+        hideAndSwitch(targetWindow).catch(() => {});
       }
     },
     [hideAndSwitch]

--- a/src/hooks/useSettingsAppState.ts
+++ b/src/hooks/useSettingsAppState.ts
@@ -21,7 +21,9 @@ export function useSettingsAppState() {
         setConfig(cfg);
         setAutoSwitchState(cfg.settings?.auto_switch_on_overlay ?? "ask");
       })
-      .catch(console.error);
+      .catch(() => {
+        // getConfig 失败由 invoke 包装 toast 提示。
+      });
     getAppVersion().then(setVersion).catch(() => {});
 
     // 简体中文用户首次启动自动启用中国大陆加速镜像（仅初始化一次，不覆盖用户选择）。

--- a/src/hooks/useUpdateConfig.ts
+++ b/src/hooks/useUpdateConfig.ts
@@ -11,7 +11,7 @@ export function useUpdateConfig(config: AppConfig | null, setConfig: (cfg: AppCo
         settings: { ...config.settings, [key]: value },
       };
       setConfig(newConfig);
-      updatePreferences({ [key]: value } as Partial<AppConfig["settings"]>).catch(console.error);
+      updatePreferences({ [key]: value } as Partial<AppConfig["settings"]>).catch(() => {});
     },
     [config, setConfig]
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -297,7 +297,13 @@
     "right": "R",
     "gridCells": "Grid Cells",
     "gridSize": "Cell Width",
-    "gridAlignment": "Alignment"
+    "gridAlignment": "Alignment",
+    "dotCount": "Dot Count"
+  },
+  "cornerDotsCount": {
+    "4": "4 dots (corners)",
+    "6": "6 dots (corners + T/B mid)",
+    "8": "8 dots (corners + edge mids)"
   },
   "preview": {
     "placeholder": "Please select a PNG file",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -297,7 +297,13 @@
     "right": "右",
     "gridCells": "格子数",
     "gridSize": "格子宽度",
-    "gridAlignment": "对齐方式"
+    "gridAlignment": "对齐方式",
+    "dotCount": "点数"
+  },
+  "cornerDotsCount": {
+    "4": "4 点（四角）",
+    "6": "6 点（四角+上下中）",
+    "8": "8 点（四角+四边中）"
   },
   "preview": {
     "placeholder": "请选择 PNG 文件",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke as tauriInvoke, type InvokeArgs } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { showToast } from "@/lib/globalErrorToast";
 import type {
   AppConfig,
   BuiltShape,
@@ -10,6 +11,49 @@ import type {
 } from "@/types/config";
 
 export { getCurrentWebviewWindow };
+
+// ===== IPC 结构化错误协议 =====
+
+/** 后端 IpcError 对象（与 `src-tauri/src/lib.rs::IpcError` 对应）。 */
+export interface IpcError {
+  /** 稳定错误码（VALIDATION / NOT_FOUND / INTERNAL）。 */
+  code: string;
+  /** 人类可读的错误描述（中文）。 */
+  message: string;
+}
+
+/**
+ * 统一 IPC 调用包装：捕获后端 reject（IpcError 对象或遗留字符串），
+ * 包装为标准 `Error`（携带 `code` 属性），通过 `showToast` 显示后重新抛出。
+ *
+ * 调用方只需 try/catch 处理 UI 回滚，不必重复 toast 样板代码。
+ */
+export async function invoke<T>(cmd: string, args?: InvokeArgs): Promise<T> {
+  try {
+    return await tauriInvoke<T>(cmd, args);
+  } catch (e) {
+    // Tauri IPC reject 出来的可能是 IpcError 对象（新协议）或字符串（遗留）。
+    const isObj = typeof e === "object" && e !== null;
+    const code = isObj && typeof (e as { code?: unknown }).code === "string"
+      ? (e as IpcError).code
+      : "UNKNOWN";
+    const msg = typeof e === "string"
+      ? e
+      : isObj && typeof (e as { message?: unknown }).message === "string"
+        ? (e as IpcError).message
+        : String(e);
+    const err = new Error(msg) as Error & { code: string };
+    err.code = code;
+    // 统一 toast 显示，用户看到「为什么没保存」。
+    showToast(msg);
+    throw err;
+  }
+}
+
+/** 更新 profile 顶层字段（强类型枚举，与后端 `ProfileFieldUpdate` 对应）。 */
+export type ProfileFieldUpdate =
+  | { kind: "target_window"; value: string }
+  | { kind: "settings_hotkey"; value: string };
 
 export async function getConfig(): Promise<AppConfig> {
   return invoke<AppConfig>("get_config");
@@ -218,3 +262,13 @@ export async function copyProfile(baseName: string): Promise<string> {
   return invoke<string>("copy_profile", { baseName });
 }
 
+/** 字段级 patch 更新 Profile 顶层字段（不触及 layers/crosshair）。
+ *
+ * 用于多图层编辑链路替代全量 saveConfig，根治配置丢失。
+ */
+export async function updateProfileField(
+  profileName: string,
+  update: ProfileFieldUpdate,
+): Promise<void> {
+  return invoke("update_profile_field", { profileName, update });
+}

--- a/src/lib/globalErrorToast.ts
+++ b/src/lib/globalErrorToast.ts
@@ -44,7 +44,7 @@ interface ToastEntry {
 const toasts: ToastEntry[] = [];
 let nextId = 1;
 
-function showToast(message: string, stack?: string): void {
+export function showToast(message: string, stack?: string): void {
   const id = nextId++;
   toasts.push({ id, message, stack });
   renderToasts();

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -99,6 +99,13 @@ export interface MaterialSchemaEntry {
    * 用于 random_orb.mode 等暂未实现的字段。
    */
   coming_soon?: boolean;
+  /** 位掩码控件标记：widget 为 number 时，前端识别此标记后渲染为 4 个 checkbox
+   * （上/下/左/右），位 1=top, 2=bottom, 4=left, 8=right。
+   *
+   * 用于 custom_orb.orb_positions、edge_arrows.positions_mask 等位掩码字段，
+   * 替代裸数字输入，提升多图层模式下的可操作性。
+   */
+  bitmask?: boolean;
 }
 
 /** 物料信息（IPC `list_materials` 返回）。 */

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -94,6 +94,11 @@ export interface MaterialSchemaEntry {
   step?: number;
   options?: { value: string | number; label: string }[];
   default?: unknown;
+  /** 任务 9.7：select 控件标记为「开发中」，前端禁用并显示提示。
+   *
+   * 用于 random_orb.mode 等暂未实现的字段。
+   */
+  coming_soon?: boolean;
 }
 
 /** 物料信息（IPC `list_materials` 返回）。 */


### PR DESCRIPTION
## 概述

系统性修复 v0.2.1 稳定版多图层编辑链路暴露的 9 个 issue（#27~#35），把多图层链路从「能演示」提升到「可日常使用」。

Closes #27
Closes #28
Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34

## 修复清单

| Issue | 严重度 | 修复内容 |
|---|---|---|
| #34 配置丢失 | 🔴 严重 | 新增 `update_profile_field` patch API + layers-changed 事件同步整个 config |
| #27 错误协议 | 🔴 根因 | IPC `Result<T, String>` -> `Result<T, IpcError>` 结构化 `{code, message}` |
| #31 错误反馈 | 🟠 高 | 统一 invoke 包装 + toast，所有图层操作加 try/catch |
| #28 全局对话框 | 🟠 高 | AutoSwitchDialog/UpdateDialog/UpdateProgress 移到全局层 |
| #29 grid 算错 | 🟡 中 | cols/rows 改用 floor，cell_w 用用户设定值 |
| #30 dead param | 🟡 中 | border_frame.inset / edge_rect.corner_radius / random_orb.center_deviation 实现；mode 禁用 |
| #32 透明度显示 | 🟡 中 | SliderField 新增 format 回调，opacity 显示 0-100% |
| #33 slider max | 🟡 中 | 按分级表统一扩充：距离=1920、半径=500、线粗=50 等 |
| #35 README 视频 | ⚪ 低 | 本次未处理（独立小改动，留待后续） |

## 详细改动

### 后端（Rust）
- `src-tauri/src/lib.rs`：定义 `IpcError` / `ipc_error_code` / `ProfileFieldUpdate`；所有图层/profile 命令返回 `Result<T, IpcError>`；新增 `update_profile_field` 命令
- `crates/config/src/schema.rs`：`Element::Rect` 新增 `corner_radius: Option<f32>`（serde default，向后兼容）
- `crates/peregrine/src/svg_renderer.rs`：SVG `<rect>` 支持 `rx` 属性
- `crates/peregrine/src/overlay_renderer.rs`：CPU 圆角矩形降级为直角 + warn 日志
- `crates/material/builtin/*.rhai`：11 个物料脚本修复算法 bug + 实现 dead parameter + 扩充 slider max

### 前端（TypeScript / React）
- `src/lib/api.ts`：统一 `invoke<T>` 包装（捕获 reject -> Error + toast），新增 `updateProfileField`
- `src/lib/globalErrorToast.ts`：export `showToast`
- `src/components/LayersEditor.tsx`：`updateTargetWindow` 改走 patch API；layers-changed 监听器同步整个 config
- `src/components/LayerPanel.tsx` / `LayerEditors.tsx`：所有图层操作加 try/catch
- `src/ConfigApp.tsx`：全局对话框层重构（三元表达式并列）；opacity 显示百分比
- `src/components/fields/SliderField.tsx`：新增 `format?: (v) => string` 回调
- 移除所有图层/profile 操作相关的 `.catch(console.error)`

### 测试
- 新增 3 个单元测试
- `cargo test --workspace` 全 130 个测试通过
- `cargo check --workspace` 通过
- `npm run build` 通过

## BREAKING 变更

IPC 错误协议改造是 BREAKING：所有图层/profile 命令的 reject 类型从字符串变为 `IpcError` 对象。前端通过统一 invoke 包装兼容（同时处理对象和字符串两种形态，兼容过渡期）。

## 未完成 / 待手测

代码改动 100% 完成，snapshot workflow 触发后下载测试包验证：
- [ ] 5.4 多图层下改 target_window 不丢图层
- [ ] 6.6/6.7 多图层模式下对话框正常弹出
- [ ] 7.5 两种模式 opacity 显示百分比
- [ ] 8.4/8.5 grid 渲染列数正确
- [ ] 10.12 cross 物料 size 可拖到 1920
- [ ] 12.x 完整回归手测
- [ ] 11.x README 嵌入视频（本次未做）

## OpenSpec

本 PR 对应 openspec change：`fix-overlay-config-loss-and-bugs`。归档将在 PR 合并后执行。