### PR TITLE
docs(contributing): 新增根目录 CONTRIBUTING.md 并对齐文档站语言约定

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing to Peregrine
+
+Thanks for your interest in contributing! 🎉
+
+The full contributing guide — branch naming, commit conventions, development
+workflow, code style, testing requirements, and the pull request process — is
+maintained on the documentation site:
+
+- **English**: https://peregrine.aukcraft.org/guide/contributing.html
+- **简体中文**: https://peregrine.aukcraft.org/zh-cn/guide/contributing.html
+
+Quick links:
+
+- 🐛 **Bug reports & feature requests** — use the [issue templates](https://github.com/Eeymoo/peregrine/issues/new/choose)
+- 🌐 **Translation improvements** — [translation-improvement template](https://github.com/Eeymoo/peregrine/issues/new?template=translation-improvement.yml)
+- 💬 **Questions & ideas** — [GitHub Discussions](https://github.com/Eeymoo/peregrine/discussions)

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -65,7 +65,7 @@ docs: add contributing guide and startup instructions
 ci(release): only build and release Windows x86/x86_64/ARM64
 ```
 
-As the project is moving toward internationalization, commit message bodies should be written in **English**. `type` and `scope` remain in English.
+Commit message bodies should be written in **Simplified Chinese** (consistent with the repository convention in `AGENTS.md`); `type` and `scope` remain in English. Issue and Pull Request descriptions, however, may be written in English — this language convention applies only to code comments, documentation, and commit messages.
 
 ---
 
@@ -90,7 +90,7 @@ As the project is moving toward internationalization, commit message bodies shou
 ## Code Style
 
 - Follow standard Rust style (`cargo fmt` default configuration).
-- As the project is internationalized, please write **English** documentation comments (`///`) for public items, and use `//!` at the top of modules to describe responsibilities.
+- As per the repository convention (`AGENTS.md`), please write **Simplified Chinese** documentation comments (`///`) for public items, and use `//!` at the top of modules to describe responsibilities.
 - Error handling: use `ConfigError` defined by `thiserror` at the library level; do not `panic`/`unwrap` in libraries.
 - Logging uses `tracing`; do not add new `println!`/`eprintln!`.
 - When adding new fields, be sure to add `#[serde(default)]` to maintain backward compatibility.

--- a/docs/zh-cn/guide/contributing.md
+++ b/docs/zh-cn/guide/contributing.md
@@ -65,7 +65,7 @@ docs: add contributing guide and startup instructions
 ci(release): only build and release Windows x86/x86_64/ARM64
 ```
 
-随着项目国际化，提交信息主体建议使用**英文**描述内容，但 type/scope 保持英文。
+提交信息主体（message body）请使用**简体中文**撰写，与仓库约定（`AGENTS.md`）保持一致；type/scope 保持英文。但 Issue 与 Pull Request 的描述可使用英文——本约定仅适用于代码注释、文档与 commit 信息。
 
 ---
 
@@ -90,7 +90,7 @@ ci(release): only build and release Windows x86/x86_64/ARM64
 ## 代码风格
 
 - 遵循标准 Rust 风格（`cargo fmt` 默认配置）。
-- 随着项目国际化，公开项的文档注释建议改用**英文**（`///`），模块顶部用 `//!` 说明职责。
+- 按仓库约定（`AGENTS.md`），公开项的文档注释（`///`）请使用**简体中文**撰写，模块顶部用 `//!` 说明职责。
 - 错误处理：库层统一用 `thiserror` 定义的 `ConfigError`，不要在库中 `panic`/`unwrap`。
 - 日志使用 `tracing`，不要新增 `println!`/`eprintln!`。
 - 新增字段时务必加 `#[serde(default)]` 保持向后兼容。

--- a/openspec/changes/add-contributing-readme/.openspec.yaml
+++ b/openspec/changes/add-contributing-readme/.openspec.yaml
@@ -3,3 +3,4 @@ created: 2026-08-12
 status: active
 issue: 49
 branch: feature/add-contributing-readme
+pr: 50

--- a/openspec/changes/add-contributing-readme/.openspec.yaml
+++ b/openspec/changes/add-contributing-readme/.openspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-08-12
+status: active
+issue: 49
+branch: feature/add-contributing-readme

--- a/openspec/changes/add-contributing-readme/design.md
+++ b/openspec/changes/add-contributing-readme/design.md
@@ -1,0 +1,78 @@
+## Context
+
+仓库现状（已在探索阶段勘察确认）：
+
+- 根目录 `CONTRIBUTING.md` 在 `main` 上不存在（`git ls-tree origin/main` 无此文件，GitHub 页面 404）。
+- `README.md` 第 12 行已将贡献者引导至文档站 `https://peregrine.aukcraft.org/guide/contributing.html`。
+- 文档站已有完整贡献指南：`docs/guide/contributing.md`（英文，131 行）与 `docs/zh-cn/guide/contributing.md`（中文镜像），覆盖分支命名、Conventional Commits、开发流程、代码风格、测试要求、PR 流程（Squash & Merge）、Issue 要素。
+- `.github/ISSUE_TEMPLATE/` 已有 4 个模板（`bug_report` / `feature_proposal` / `question` / `translation-improvement`），`config.yml` 含文档站与 Discussions 的 contact links。
+- **冲突**：`docs/guide/contributing.md` L68 称 commit body 用英文、L93 称代码注释用英文；`AGENTS.md` 规定注释 / 文档 / commit body 一律简体中文；git 历史实际以中文为主。
+
+约束：所有产出物用简体中文撰写；本次为纯文档变更，不触碰代码。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 根目录新增英文瘦指针 `CONTRIBUTING.md`，GitHub 新建 issue / PR 时可正常引导。
+- 文档站贡献指南的语言约定修正为与 `AGENTS.md` 一致（简体中文），消除三处真相源之间的矛盾。
+- 完整指南维持单一维护点（文档站），根目录文件零复制、零漂移风险。
+
+**Non-Goals:**
+
+- 不复制完整贡献流程到根目录文件。
+- 不裁定分支前缀 `feat/` vs `feature/` 的冲突（遗留问题）。
+- 不改动代码、CI、issue 模板。
+
+## Decisions
+
+### 决策 1：根目录文件采用「瘦指针」而非「精华版」或「全量镜像」
+
+- **选择**：瘦指针——欢迎语 + 完整指南链接（英 / 中）+ issue 模板 / Discussions 快捷入口。
+- **备选**：
+  - 精华版（自包含核心流程 + 链接）：内容与文档站部分重叠，仍有漂移面；用户已明确选瘦指针。
+  - 全量镜像：两处维护同一内容，必然漂移，直接排除。
+- **理由**：完整指南已在文档站双语维护；README 已指向文档站；瘦指针把根目录文件的维护成本降为零，且满足 GitHub 的展示约定。
+
+### 决策 2：根目录文件用英文，不建中文副本
+
+- **选择**：单一英文文件，文件内给出 zh-cn 文档站链接。
+- **备选**：仿 README 的 `CONTRIBUTING.zh-cn.md` 双文件——增加一个几乎不会被单独维护的文件；中文读者经链接跳转即可。
+- **理由**：GitHub 场景面向国际贡献者，英文是默认语言；中文完整指南在文档站已存在。
+
+### 决策 3：语言约定冲突以 `AGENTS.md`（简体中文）为准
+
+- **选择**：修正文档站两页——commit message body 与代码文档注释（`///`、`//!`）使用简体中文。
+- **备选**：以文档站（英文）为准——需要改写 `AGENTS.md` 并逆转既有中文注释存量，成本与影响面大得多。
+- **理由**：`AGENTS.md` 是仓库现行约定且与 git 历史实践一致；文档站的相关表述是早期「国际化」设想的遗留，未落地。
+- **配套澄清**：在两份页面补充说明——中文约定仅针对代码注释 / 文档 / commit body；Issue 与 PR 描述用英文仍然欢迎，避免误伤非中文贡献者。
+
+### 决策 4：根目录文件内容结构
+
+```markdown
+# Contributing to Peregrine
+
+<一句欢迎语>
+
+完整贡献指南（分支命名、commit 规范、开发流程、代码风格、测试要求、PR 流程）
+在文档站维护：
+- English: https://peregrine.aukcraft.org/guide/contributing.html
+- 简体中文: https://peregrine.aukcraft.org/zh-cn/guide/contributing.html
+
+快捷入口：
+- Bug 报告 / 功能建议 → issue 模板（issues/new/choose）
+- 翻译改进 → translation-improvement 模板
+- 问题与讨论 → GitHub Discussions
+```
+
+链接全部使用文档站线上地址（与 README 第 12 行一致），不链仓库内相对路径，保证在 GitHub 以外场景（如克隆后本地阅读）也可达。
+
+## Risks / Trade-offs
+
+- [根目录瘦指针过于简略，贡献者可能跳过阅读完整指南] → 快捷入口直接列出 issue 模板与 Discussions，即使不点指南链接也能完成最低成本的正确动作。
+- [文档站地址变更会导致链接失效] → 链接与 README 第 12 行同源，地址变更时需一并更新；该域名（`peregrine.aukcraft.org`）为项目自有自定义域，变更概率低。
+- [修正文档站语言约定可能与未来真正的国际化方向冲突] → 本次仅对齐现状并在 spec 中固化；未来若转向英文注释，属新的 spec 级变更，需另立 change。
+
+## Open Questions
+
+- 分支前缀 `feat/`（文档站）vs `feature/`（OpenSpec 工作流实践）的统一：留待后续 change 裁定。

--- a/openspec/changes/add-contributing-readme/proposal.md
+++ b/openspec/changes/add-contributing-readme/proposal.md
@@ -1,0 +1,41 @@
+> **跟踪 issue：#49**（https://github.com/Eeymoo/peregrine/issues/49）
+
+## Why
+
+仓库根目录的 `CONTRIBUTING.md` 在 `main` 上不存在（GitHub 页面 404），而 GitHub 会在贡献者新建 issue / PR 时自动提示阅读该文件，缺失会削弱引导效果。同时勘察发现文档站贡献指南（`docs/guide/contributing.md` 及其 zh-cn 镜像）与仓库现行约定存在冲突：文档站称「commit body 与代码注释用英文（项目走向国际化）」，而 `AGENTS.md` 明确规定「代码注释、文档、commit message body 一律使用简体中文」，实际 git 历史也以中文为主。补充根目录文件的同时应一并裁定并修正该冲突，避免新文件把矛盾固化。
+
+## What Changes
+
+- 新建根目录 `CONTRIBUTING.md`：英文**瘦指针**文件，仅含欢迎语、完整贡献指南链接（英文 / 简体中文文档站页面）、issue 模板与 Discussions 快捷入口；不复制文档站内容，避免双份维护漂移。
+- 修正 `docs/guide/contributing.md`（英文页）：commit message body 语言约定由「英文」改为「简体中文」；代码文档注释语言约定由「英文」改为「简体中文」，与 `AGENTS.md` 对齐。
+- 同步修正 `docs/zh-cn/guide/contributing.md`（中文页）中的对应表述。
+- 在两份文档站页面补充澄清：中文约定仅针对代码注释 / 文档 / commit body；Issue 与 PR 描述使用英文仍然欢迎（面向国际审阅者）。
+
+## 目标
+
+- 根目录出现一份自包含的英文 `CONTRIBUTING.md`，GitHub 提 issue / PR 场景可正常引导贡献者。
+- 贡献指南的「注释 / commit body 语言」约定在全仓库范围内统一为简体中文（以 `AGENTS.md` 为准），消除文档间矛盾。
+- 根目录文件保持瘦指针形态，完整指南仍单一维护在文档站。
+
+## 非目标
+
+- 不在根目录 `CONTRIBUTING.md` 中复制文档站的完整贡献流程（分支命名、commit 规范、PR 流程等）。
+- 不处理「分支前缀 `feat/` vs `feature/`」的文档冲突（挂为遗留问题，另行裁定）。
+- 不新建中文版根目录 `CONTRIBUTING.zh-cn.md`（中文读者经链接跳转文档站 zh-cn 页面）。
+- 不改动任何代码、CI 工作流或 issue 模板。
+
+## Capabilities
+
+### New Capabilities
+
+- `contributor-guide`: 贡献者引导文档的存在性与内容约定——根目录 `CONTRIBUTING.md` 作为指向文档站完整指南的瘦指针；贡献指南中的语言约定（代码注释 / 文档 / commit message body 使用简体中文）与 `AGENTS.md` 保持一致。
+
+### Modified Capabilities
+
+<!-- 无：本次不涉及既有 spec 级行为变更 -->
+
+## Impact
+
+- **文档**：新增 `CONTRIBUTING.md`（根目录）；修改 `docs/guide/contributing.md`、`docs/zh-cn/guide/contributing.md`。
+- **代码 / API / 依赖**：无影响。
+- **CI**：`pages.yml` 文档站部署流程在下次稳定版 Release 或手动触发时自动携带修正后的页面，无需额外操作。

--- a/openspec/changes/add-contributing-readme/specs/contributor-guide/spec.md
+++ b/openspec/changes/add-contributing-readme/specs/contributor-guide/spec.md
@@ -1,0 +1,45 @@
+# contributor-guide 规格增量
+
+## ADDED Requirements
+
+### Requirement: 根目录贡献指南入口文件
+
+仓库根目录 SHALL 存在 `CONTRIBUTING.md`，作为贡献者引导的入口文件，在 GitHub 新建 issue / PR 场景下可被自动提示阅读。该文件 MUST 使用英文撰写，且 MUST 为「瘦指针」形态：仅包含欢迎语、指向文档站完整贡献指南的链接与常用贡献入口，MUST NOT 复制文档站贡献指南的正文内容（分支命名、commit 规范、开发流程、PR 流程等）。
+
+#### Scenario: GitHub 场景引导贡献者
+
+- **WHEN** 贡献者在 GitHub 上新建 issue 或 Pull Request
+- **THEN** GitHub 提示阅读的 `CONTRIBUTING.md` 存在，且其中包含指向文档站完整贡献指南的链接
+
+#### Scenario: 完整指南单一维护点
+
+- **WHEN** 贡献流程（如分支命名、commit 规范、PR 流程）发生变更
+- **THEN** 只需修改文档站贡献指南页面，根目录 `CONTRIBUTING.md` 无需同步修改
+
+### Requirement: 双语完整指南可达性
+
+根目录 `CONTRIBUTING.md` MUST 同时提供文档站英文页（`/guide/contributing.html`）与简体中文页（`/zh-cn/guide/contributing.html`）的链接，使中文读者可以一键跳转到中文完整指南。链接 MUST 使用文档站线上地址，与 `README.md` 中既有链接保持同源。
+
+#### Scenario: 中文读者跳转
+
+- **WHEN** 中文贡献者打开根目录 `CONTRIBUTING.md`
+- **THEN** 文件内存在指向简体中文完整贡献指南的链接
+
+#### Scenario: 英文读者跳转
+
+- **WHEN** 英文贡献者打开根目录 `CONTRIBUTING.md`
+- **THEN** 文件内存在指向英文完整贡献指南的链接
+
+### Requirement: 注释与提交信息语言约定一致
+
+文档站贡献指南（英文页与简体中文页）中的语言约定 MUST 与 `AGENTS.md` 保持一致：代码注释（`///`、`//!`）、文档与 commit message body 使用简体中文。文档站页面 MUST NOT 出现要求上述内容使用英文的表述。同时页面 MUST 澄清该约定不适用于 Issue 与 PR 描述——后者使用英文仍然被接受。
+
+#### Scenario: 文档间约定无冲突
+
+- **WHEN** 贡献者对照阅读 `AGENTS.md` 与文档站贡献指南
+- **THEN** 两者对代码注释 / 文档 / commit message body 的语言要求一致（均为简体中文）
+
+#### Scenario: 非中文贡献者不被误伤
+
+- **WHEN** 非中文贡献者阅读文档站贡献指南的语言约定章节
+- **THEN** 页面明确说明 Issue 与 PR 描述可使用英文

--- a/openspec/changes/add-contributing-readme/tasks.md
+++ b/openspec/changes/add-contributing-readme/tasks.md
@@ -1,0 +1,19 @@
+# 实施任务清单
+
+## 1. 根目录 CONTRIBUTING.md
+
+- [x] 1.1 在仓库根目录新建 `CONTRIBUTING.md`（英文瘦指针）：欢迎语 + 文档站完整指南双语链接（`https://peregrine.aukcraft.org/guide/contributing.html` 与 `https://peregrine.aukcraft.org/zh-cn/guide/contributing.html`）+ 快捷入口（issue 模板选择页、translation-improvement 模板、GitHub Discussions）
+- [x] 1.2 校验文件中不含文档站贡献指南的正文内容（分支命名、commit 规范、PR 流程等不得复制），链接与 `README.md` 第 12 行同源
+
+## 2. 文档站语言约定修正
+
+- [x] 2.1 修改 `docs/guide/contributing.md`（英文页）：commit message body 语言约定由「English」改为「Simplified Chinese」（约 L68），代码文档注释语言约定由「English」改为「Simplified Chinese」（约 L93）
+- [x] 2.2 在 `docs/guide/contributing.md` 语言约定相关章节补充澄清：中文约定仅针对代码注释 / 文档 / commit body，Issue 与 PR 描述使用英文仍然欢迎
+- [x] 2.3 同步修改 `docs/zh-cn/guide/contributing.md`（中文页）中的对应表述与澄清说明
+- [x] 2.4 复查两份页面，确认不再存在「注释 / commit body 用英文」的残留表述，且与 `AGENTS.md` 约定一致
+
+## 3. 验证
+
+- [x] 3.1 运行 `openspec validate add-contributing-readme`（或等效命令）确认变更产物合法
+- [x] 3.2 本地构建文档站（`cd docs && npm ci && npm run docs:build`）确认两份修改后的页面无 VitePress 构建错误
+- [x] 3.3 对照 spec 场景逐项自查：GitHub 入口存在、双语链接可达（链接地址正确）、语言约定无冲突、非中文贡献者澄清已写明


### PR DESCRIPTION
## 关联 OpenSpec change

- Change: `add-contributing-readme`（`openspec/changes/add-contributing-readme/`）
- Issue: #49
- 提案 / 设计 / 任务：proposal.md / design.md / tasks.md

## 变更摘要

- 新增根目录 `CONTRIBUTING.md`：英文瘦指针，链接文档站完整贡献指南（英 / 中）+ issue 模板 / Discussions 快捷入口，GitHub 提 issue / PR 时可正常引导。
- 修正 `docs/guide/contributing.md` 与 `docs/zh-cn/guide/contributing.md` 的语言约定：commit body 与代码注释由「英文」改为「简体中文」，与 `AGENTS.md` 一致；并澄清 Issue / PR 描述仍可用英文。
- 完整指南维持文档站单一维护点，根目录文件零复制、零漂移。

## 验证

- [x] `openspec validate add-contributing-readme` 通过
- [x] `npm run docs:build` 文档站构建成功（无 VitePress 错误）
- [x] 对照 spec 场景自查：GitHub 入口存在、双语链接可达、语言约定无冲突、非中文贡献者澄清已写明

Closes #49