### PR TITLE
fix(docs): Hero 主 CTA 跳转站内下载页

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -7,7 +7,7 @@ hero:
   tagline: A transparent overlay pins customizable visual anchors over any game window, giving your eyes a fixed reference point.
   actions:
     - text: Download Now
-      link: https://github.com/eeymoo/peregrine/releases
+      link: /download
       variant: primary
       icon: right-arrow
     - text: Learn More

--- a/docs/src/content/docs/zh-cn/index.mdx
+++ b/docs/src/content/docs/zh-cn/index.mdx
@@ -7,7 +7,7 @@ hero:
   tagline: 透明覆盖层把可定制的视觉锚点固定在游戏窗口上，给眼睛一个稳定的参照点。
   actions:
     - text: 立即下载
-      link: https://github.com/eeymoo/peregrine/releases
+      link: /zh-cn/download
       variant: primary
       icon: right-arrow
     - text: 了解更多


### PR DESCRIPTION
Download Now / 立即下载 原先外链 GitHub Releases，与下载区三架构按钮的站内下载页入口不一致。改为 `/download`（en）与 `/zh-cn/download`（zh），由下载页承接架构选择与加速通道。

单行 frontmatter 修改（双语 index.mdx），本地 `npm run build && npm run verify` 全绿。

属 #65 / docs-aukcraft-shell 的收尾修复（承接 #66）。