### PR TITLE
fix(docs): 清除区块 2/3 多余横线 + Hero CTA 跳下载页 + 落地页隐藏编辑时间

### DIFF
--- a/docs/scripts/verify-landing.mjs
+++ b/docs/scripts/verify-landing.mjs
@@ -168,8 +168,8 @@ for (const theme of ['dark', 'light']) {
       JSON.stringify(r.hwGrid),
     );
     check(
-      `${t} hw 步骤发丝线`,
-      r.hwStep?.borderTopWidth === '1px' && r.hwStep?.borderTopStyle === 'solid' && r.hwStep?.paddingTop === '20px',
+      `${t} hw 步骤无额外线（仅标题后一条）`,
+      r.hwStep?.borderTopWidth === '0px' && r.hwStep?.paddingTop === '20px',
       JSON.stringify(r.hwStep),
     );
     check(

--- a/docs/src/components/landing/DownloadCta.astro
+++ b/docs/src/components/landing/DownloadCta.astro
@@ -44,7 +44,7 @@ const artifacts = [
 const downloadIcon = lucideIcon('Download');
 ---
 
-<div class="dl-block not-content border-t border-(--sl-color-hairline) pt-10 text-center" data-pagefind-ignore>
+<div class="dl-block not-content pt-10 text-center" data-pagefind-ignore>
   <div class="dl-buttons flex flex-wrap justify-center gap-3">
     {
       artifacts.map((a, i) => (

--- a/docs/src/components/landing/HowItWorks.astro
+++ b/docs/src/components/landing/HowItWorks.astro
@@ -20,7 +20,7 @@ const { steps } = Astro.props;
 <ol class="hw-grid not-content m-0 grid list-none grid-cols-1 gap-8 p-0 lg:grid-cols-3 lg:gap-10" data-pagefind-ignore>
   {
     steps.map((step, i) => (
-      <li class="hw-step border-t border-solid border-(--sl-color-hairline) pt-5">
+      <li class="hw-step pt-5">
         <span
           class="hw-index font-mono text-[0.8125rem] font-semibold tracking-[0.12em] text-accent-600 tabular-nums dark:text-accent-200"
           aria-hidden="true"

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -2,6 +2,8 @@
 title: Peregrine
 description: Peregrine is a desktop visual anchor tool designed to reduce 3D motion sickness
 template: splash
+editUrl: false
+lastUpdated: false
 hero:
   title: 'Play 3D games without the <em>dizziness</em>'
   tagline: A transparent overlay pins customizable visual anchors over any game window, giving your eyes a fixed reference point.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -7,7 +7,7 @@ hero:
   tagline: A transparent overlay pins customizable visual anchors over any game window, giving your eyes a fixed reference point.
   actions:
     - text: Download Now
-      link: https://github.com/eeymoo/peregrine/releases
+      link: /download
       variant: primary
       icon: right-arrow
     - text: Learn More

--- a/docs/src/content/docs/zh-cn/index.mdx
+++ b/docs/src/content/docs/zh-cn/index.mdx
@@ -7,7 +7,7 @@ hero:
   tagline: 透明覆盖层把可定制的视觉锚点固定在游戏窗口上，给眼睛一个稳定的参照点。
   actions:
     - text: 立即下载
-      link: https://github.com/eeymoo/peregrine/releases
+      link: /zh-cn/download
       variant: primary
       icon: right-arrow
     - text: 了解更多

--- a/docs/src/content/docs/zh-cn/index.mdx
+++ b/docs/src/content/docs/zh-cn/index.mdx
@@ -2,6 +2,8 @@
 title: Peregrine
 description: Peregrine 是桌面视觉锚点工具，专为缓解 3D 眩晕而设计
 template: splash
+editUrl: false
+lastUpdated: false
 hero:
   title: 玩 3D 游戏，不再<em class="serif-zh">眩晕</em>
   tagline: 透明覆盖层把可定制的视觉锚点固定在游戏窗口上，给眼睛一个稳定的参照点。


### PR DESCRIPTION
承接 #65/#66/#67 的落地页收尾修复。

## 变更

1. **区块 2/3 标题下多余横线**
   - `HowItWorks` 步骤去掉 `border-top`（三条步骤顶线与标题 `sh-rule` 视觉重复）
   - `DownloadCta` 去掉 `dl-block` 的 `border-t`（下载区块整条横线）
   - 现在每个区块只保留标题文字后的一条 `sh-rule` 贯穿线（实测 h2 `border-bottom: 0`、`hw-step`/`dl-block` `border-top: 0`）
2. **Footer 位置**：双语 `index.mdx` frontmatter 加 `editUrl: false` / `lastUpdated: false`，隐藏 Starlight 内置的 Edit page / Last updated，避免压在自定义 Footer 下方（Footer 现为页面最末元素）
3. **Hero 主 CTA**：Download Now / 立即下载 改跳站内下载页 `/download`、`/zh-cn/download`（cherry-pick 自 #67 同内容，本分支基于最新 main）

本地 `npm run build && npm run verify` 全绿（明暗/双语/移动/reduced-motion）。

> 注：本 PR 基于最新 main，已包含 #67 的 CTA 链接修复（内容一致），合并本 PR 后 #67 可关闭或自动冲突消解。