### PR TITLE
feat(docs): 头栏居中容器 + 搜索 .flight 按钮 + utilities 重构（#69 后续）

### DIFF
--- a/docs/scripts/verify-landing.mjs
+++ b/docs/scripts/verify-landing.mjs
@@ -98,8 +98,15 @@ for (const theme of ['dark', 'light']) {
         dlButtons: qa('.dl-button').map((a) => a.textContent.trim() + ' -> ' + a.getAttribute('href')),
         headerNav: qa('.header-nav-link').map((a) => a.getAttribute('href')),
         // Header 导航区计算样式基线（aukcraft 平铺头栏，header-aukcraft-nav）
+        headerBox: cs('div.header', ['maxWidth', 'marginLeft']),
         hnNav: cs('.header-nav', ['display', 'alignItems', 'gap']),
-        hnLink: cs('.header-nav-link', ['display', 'alignItems', 'fontSize', 'fontWeight', 'color', 'textDecorationLine', 'whiteSpace', 'transitionProperty', 'transitionDuration']),
+        hnLink: cs('.header-nav-link', ['fontFamily', 'fontSize', 'color', 'textDecorationLine', 'whiteSpace']),
+        hnLinkAfter: (() => {
+          const el = q('.header-nav-link');
+          if (!el) return null;
+          const s = getComputedStyle(el, '::after');
+          return { height: s.height, transform: s.transform, duration: s.transitionDuration };
+        })(),
         // 新头栏控件：语言平铺切换 / 主题图标按钮 / 图标化搜索
         langToggle: (() => {
           const el = q('.lang-toggle');
@@ -321,24 +328,25 @@ for (const theme of ['dark', 'light']) {
       const contrast = (Math.max(fg, bg) + 0.05) / (Math.min(fg, bg) + 0.05);
       check(`${t} 暗色 CTA primary 对比度 ≥4.5:1`, contrast >= 4.5, contrast.toFixed(2));
     }
-    // Header 导航区计算样式（aukcraft 平铺头栏，header-aukcraft-nav）
-    const hnLinkColor = theme === 'dark' ? 'rgb(198, 207, 215)' : 'rgb(69, 78, 90)';
+    // Header 导航区计算样式（aukcraft 平铺头栏 + .link-line 统一基元）
+    const hnLinkColor = theme === 'dark' ? 'oklch(0.882 0.059 254.128)' : 'oklch(0.546 0.245 262.881)';
+    check(
+      `${t} 头栏容器 max-w-5xl 居中`,
+      r.headerBox?.maxWidth === '1024px' && parseFloat(r.headerBox?.marginLeft) > 0,
+      JSON.stringify(r.headerBox),
+    );
     check(
       `${t} 导航容器（右侧平铺）`,
-      r.hnNav?.display === 'flex' && r.hnNav?.alignItems === 'center' && r.hnNav?.gap === '20px',
+      r.hnNav?.display === 'flex' && r.hnNav?.alignItems === 'baseline' && r.hnNav?.gap === '24px',
       JSON.stringify(r.hnNav),
     );
     check(
-      `${t} 导航链接（平铺文本 + 颜色过渡）`,
-      r.hnLink?.display === 'flex' &&
-        r.hnLink?.alignItems === 'center' &&
-        r.hnLink?.fontSize === '15px' &&
-        r.hnLink?.fontWeight === '500' &&
+      `${t} 导航链接（link-line 基元：mono 12px 品牌蓝）`,
+      r.hnLink?.fontFamily?.includes('mono') &&
+        r.hnLink?.fontSize === '12px' &&
         r.hnLink?.color === hnLinkColor &&
         r.hnLink?.textDecorationLine === 'none' &&
-        r.hnLink?.whiteSpace === 'nowrap' &&
-        r.hnLink?.transitionProperty?.includes('color') &&
-        r.hnLink?.transitionDuration === '0.2s',
+        r.hnLink?.whiteSpace === 'nowrap',
       JSON.stringify(r.hnLink),
     );
     // 语言平铺切换：EN/中文，当前语言 aria-current，另一语言为同页互转链接
@@ -376,6 +384,18 @@ for (const theme of ['dark', 'light']) {
       [...document.querySelectorAll('.header-nav-link')].every((a) => a.getAttribute('aria-current') !== 'page'),
     );
     check(`${t} 导航首页无 active 态`, hnNoActive === true);
+    // link-line 下划线：基态 scaleX(0)、300ms 过渡，hover 后生长为 scaleX(1)
+    check(
+      `${t} link-line 下划线基态`,
+      r.hnLinkAfter?.height === '1px' && r.hnLinkAfter?.duration === '0.3s' && /matrix\(0, 0, 0, 1/.test(r.hnLinkAfter?.transform ?? ''),
+      JSON.stringify(r.hnLinkAfter),
+    );
+    await page.hover('.header-nav-link');
+    await page.waitForTimeout(400);
+    const hnHoverScale = await page.evaluate(
+      () => getComputedStyle(document.querySelector('.header-nav-link'), '::after').transform,
+    );
+    check(`${t} link-line hover 下划线生长`, /matrix\(1, 0, 0, 1/.test(hnHoverScale ?? ''), hnHoverScale);
     // focus-visible 焦点环（规则级断言）：外链 CSS 无 CORS 头时 cssRules 为空，故通过
     // page 上下文 fetch 同源 CSS 文本做规则存在性断言；另验证元素 class 与规则选择器对应。
     const focusRule = await page.evaluate(async () => {

--- a/docs/scripts/verify-landing.mjs
+++ b/docs/scripts/verify-landing.mjs
@@ -133,13 +133,18 @@ for (const theme of ['dark', 'light']) {
           if (!el) return null;
           const s = getComputedStyle(el);
           const span = el.querySelector('span');
-          const kbd = el.querySelector('kbd');
+          const kbd = el.querySelector(':scope > kbd');
           return {
             borderWidth: s.borderWidth,
-            backgroundColor: s.backgroundColor,
-            iconVisible: !!el.querySelector('svg'),
+            borderRadius: s.borderRadius,
+            hasFlightClass: el.classList.contains('flight'),
+            hasFlightLine: !!el.querySelector('.flight-line'),
+            hasTrace: !!el.querySelector('.flight-line__trace'),
+            hasRing: !!el.querySelector('.flight-line__ring'),
+            iconVisible: !!el.querySelector('svg:not(.flight-line)'),
             labelHidden: !span || getComputedStyle(span).display === 'none',
-            kbdHidden: !kbd || getComputedStyle(kbd).display === 'none',
+            kbdVisible: !!kbd && getComputedStyle(kbd).display !== 'none',
+            ariaShortcuts: el.getAttribute('aria-keyshortcuts'),
           };
         })(),
         // 旧控件已移除（下拉主题/语言选择器、social 图标、AukCraft 头栏链接）
@@ -368,15 +373,21 @@ for (const theme of ['dark', 'light']) {
           : r.themeToggleBtn.moonDisplay !== 'none' && r.themeToggleBtn.sunDisplay === 'none'),
       JSON.stringify(r.themeToggleBtn),
     );
-    // 搜索图标按钮化：无边框无底色，文字标签与 kbd 隐藏，仅保留图标
+    // 搜索 .flight 按钮化：hairline 边框 + 4px + FlightLine 描边（与其他按钮同效），
+    // 图标 + kbd 快捷键提示可见，"Search" 文字标签隐藏
     check(
-      `${t} 搜索图标按钮（与头栏同效）`,
+      `${t} 搜索 .flight 按钮（描边动效 + 快捷键）`,
       r.searchIconBtn &&
-        r.searchIconBtn.borderWidth === '0px' &&
-        (r.searchIconBtn.backgroundColor === 'rgba(0, 0, 0, 0)' || r.searchIconBtn.backgroundColor === 'transparent') &&
+        r.searchIconBtn.borderWidth === '1px' &&
+        r.searchIconBtn.borderRadius === '4px' &&
+        r.searchIconBtn.hasFlightClass === true &&
+        r.searchIconBtn.hasFlightLine === true &&
+        r.searchIconBtn.hasTrace === true &&
+        r.searchIconBtn.hasRing === true &&
         r.searchIconBtn.iconVisible === true &&
         r.searchIconBtn.labelHidden === true &&
-        r.searchIconBtn.kbdHidden === true,
+        r.searchIconBtn.kbdVisible === true &&
+        !!r.searchIconBtn.ariaShortcuts,
       JSON.stringify(r.searchIconBtn),
     );
     // 首页无 active 链接（落地页不在导航项内）

--- a/docs/scripts/verify-polish.mjs
+++ b/docs/scripts/verify-polish.mjs
@@ -90,7 +90,8 @@ for (const theme of ['dark', 'light']) {
     const t = `${theme}/${name}`;
     check(`${t} aside 4px 圆角+强调条+零阴影`, r.aside?.borderRadius === '4px' && r.aside?.borderInlineStartWidth === '4px' && r.aside?.boxShadow === 'none', JSON.stringify(r.aside));
     check(`${t} 链接下划线+偏移`, r.linkDeco?.textDecorationLine?.includes('underline') && r.linkDeco?.textUnderlineOffset !== '0px', JSON.stringify(r.linkDeco));
-    // Header 导航 active 态（aukcraft 平铺头栏）：guide 页 Docs 链接应带 aria-current + is-active，文字高亮
+    // Header 导航 active 态（aukcraft 平铺头栏 + link-line）：guide 页 Docs 链接
+    // 应带 aria-current + is-active，品牌蓝 + 下划线常显
     const hnActive = await page.evaluate(() => {
       const docsLink = [...document.querySelectorAll('.header-nav-link')].find((a) => (a.getAttribute('href') || '').includes('/guide/'));
       if (!docsLink) return null;
@@ -98,14 +99,16 @@ for (const theme of ['dark', 'light']) {
         aria: docsLink.getAttribute('aria-current'),
         isActive: docsLink.classList.contains('is-active'),
         color: getComputedStyle(docsLink).color,
+        underline: getComputedStyle(docsLink, '::after').transform,
       };
     });
-    const expectActiveColor = theme === 'dark' ? 'rgb(245, 247, 249)' : 'rgb(20, 24, 29)';
+    const expectActiveColor = theme === 'dark' ? 'oklch(0.882 0.059 254.128)' : 'oklch(0.546 0.245 262.881)';
     check(
       `${t} 导航 active 态（Docs 当前页）`,
       hnActive?.aria === 'page' &&
         hnActive?.isActive === true &&
-        hnActive?.color === expectActiveColor,
+        hnActive?.color === expectActiveColor &&
+        /matrix\(1, 0, 0, 1/.test(hnActive?.underline ?? ''),
       JSON.stringify(hnActive),
     );
     await ctx.close();

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -69,7 +69,7 @@ const moonIcon = lucideIcon('Moon');
 const themeLabel = locale ? '切换主题' : 'Toggle theme';
 ---
 
-<div class="header mx-auto w-full max-w-5xl px-6">
+<div class="header mx-auto! w-full max-w-5xl! px-6">
 	<div class="title-wrapper sl-flex">
 		<SiteTitle />
 	</div>
@@ -86,7 +86,9 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 							class:list={[
 								'header-nav-link link-line font-mono text-xs whitespace-nowrap',
 								'focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-200',
-								active && 'is-active',
+								// active 态下划线常显：! 重要级任意值工具类（.link-line 基元在未分层
+								// 全局 CSS 中，普通 utilities 层规则压不过，需 ! 提升）。
+								active && 'is-active after:[transform:scaleX(1)]!',
 							]}
 							href={l.href}
 							{...(active ? { 'aria-current': 'page' } : {})}
@@ -159,19 +161,6 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 </script>
 
 <style>
-	/* active 导航链接下划线常显（.link-line 基元的 ::after），其余时刻 hover/focus 生长。 */
-	.header-nav-link.is-active::after {
-		transform: scaleX(1);
-	}
-
-	/* aukcraft 居中容器：scoped .header 规则带作用域属性选择器，特异性高于
-	 * utilities 层的 max-w-5xl / mx-auto，故在此同作用域覆写（max-w-5xl 工具类
-	 * 仍保留在 class 上作语义标注，实际生效值以此处为准）。 */
-	.header {
-		max-width: var(--container-5xl);
-		margin-inline: auto;
-	}
-
 	@layer starlight.core {
 		.header {
 			display: flex;

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -141,6 +141,21 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 				.StarlightThemeProvider?.updatePickers?.(next);
 		});
 	});
+
+	// 搜索按钮 .flight 化：注入 FlightLine SVG（与 FlightLine.astro 输出完全一致），
+	// 使 hover/focus 的边框描边动效与落地页其他 .flight 按钮保持同一实现。
+	// （Search 是 Starlight 内部组件，不能新增组件覆写，故用注入方式。）
+	document.querySelectorAll('site-search button[data-open-modal]').forEach((btn) => {
+		if (btn.querySelector('.flight-line')) return;
+		btn.classList.add('flight');
+		btn.insertAdjacentHTML(
+			'beforeend',
+			'<svg class="flight-line" aria-hidden="true" focusable="false">' +
+				'<rect class="flight-line__ring" pathLength="1"></rect>' +
+				'<rect class="flight-line__trace" pathLength="1"></rect>' +
+				'</svg>',
+		);
+	});
 </script>
 
 <style>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -3,18 +3,22 @@
  * Starlight Header 覆写（本站点仅有的第二个组件覆写，第一个是 Hero）。
  *
  * aukcraft 平铺头栏（header-aukcraft-nav）：
+ * - 容器：mx-auto max-w-5xl px-6 居中（与 aukcraft.org 顶栏同一节奏），
+ *   品牌左置、功能区右置（justify-between）；
  * - 品牌标识：图标 + 文字（SiteTitle，logo 配置见 astro.config.mjs）；
- * - 核心导航移至右侧功能区：Docs / Download / GitHub 平铺文本链接（无图标、
- *   无外链箭头），当前页 active 态仅变色；
- * - 语言切换：EN / 中文 平铺切换（斜杠分隔，无下拉）；
+ * - 核心导航右置：Docs / Download / GitHub 平铺文本链接，统一 .link-line
+ *   下划线（与落地页 Footer 链接同一基元：左→右生长、品牌蓝），active 态
+ *   下划线常显；
+ * - 语言切换：EN / 中文 平铺切换（斜杠分隔，无下拉），可点侧同样用 .link-line；
  * - 主题切换：图标按钮（sun/moon，lucide 线稿），点击在 dark/light 间翻转，
  *   写入 localStorage `starlight-theme` 与 <html data-theme>（与 Starlight
  *   ThemeProvider 协议一致）；
  * - 搜索：沿用 Starlight Search 组件，图标按钮化由 starlight-polish.css 定点
- *   覆写（隐藏文字与 ⌘K 提示，hover 与头栏链接同一过渡效果）；
+ *   覆写（隐藏文字与 ⌘K 提示，hover 与头栏图标按钮同一品牌蓝过渡）；
  * - AukCraft 外链移至落地页 Footer，不再出现在头栏。
  *
- * 头栏链接 / 图标按钮共享 .header-item 同一 hover 过渡（颜色 200ms）。
+ * 注：Starlight 头栏为固定高度的 sticky bar（--sl-nav-height），无法承载
+ * aukcraft 的 pt-10 大留白；居中分栏与链接下划线保持一致，纵向节奏保留 bar 形态。
  * 桌面端显示（md 断点以上），窄屏隐藏——移动端入口由 sidebar 顶层 link 项承担。
  * 除上述功能区外保持 @astrojs/starlight@0.41 默认 Header 结构，Starlight 升级时
  * 需对照默认 Header.astro 复核本文件。
@@ -65,26 +69,24 @@ const moonIcon = lucideIcon('Moon');
 const themeLabel = locale ? '切换主题' : 'Toggle theme';
 ---
 
-<div class="header">
+<div class="header mx-auto w-full max-w-5xl px-6">
 	<div class="title-wrapper sl-flex">
 		<SiteTitle />
 	</div>
-	<div class="search-slot sl-flex print:hidden">
+	<div class="search-slot sl-flex flex-1 print:hidden">
 		{shouldRenderSearch && <Search />}
 	</div>
 	<div class="sl-hidden md:sl-flex print:hidden right-group">
-		<nav class="header-nav flex items-center gap-5" aria-label="Top">
+		<nav class="header-nav flex items-baseline gap-6" aria-label="Top">
 			{
 				navLinks.map((l) => {
 					const active = isActive(l.href);
 					return (
 						<a
 							class:list={[
-								'header-nav-link header-item inline-flex items-center text-[0.9375rem] font-medium whitespace-nowrap no-underline transition-colors duration-200 ease-out',
+								'header-nav-link link-line font-mono text-xs whitespace-nowrap',
 								'focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-200',
-								active
-									? 'is-active text-gray-900 dark:text-gray-50'
-									: 'text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-50',
+								active && 'is-active',
 							]}
 							href={l.href}
 							{...(active ? { 'aria-current': 'page' } : {})}
@@ -96,11 +98,11 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 				})
 			}
 		</nav>
-		{/* 语言平铺切换：EN / 中文，当前语言高亮为 ink、另一语言为可点链接。 */}
-		<span class="lang-toggle flex items-center gap-1.5 font-mono text-[0.8125rem] tracking-[0.08em]">
+		{/* 语言平铺切换：EN / 中文，当前语言高亮为 ink、另一语言为 .link-line 链接。 */}
+		<span class="lang-toggle flex items-baseline gap-2 font-mono text-xs">
 			{
 				isZh ? (
-					<a class="header-item text-gray-700 no-underline transition-colors duration-200 ease-out hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-50" href={enHref}>EN</a>
+					<a class="link-line" href={enHref}>EN</a>
 				) : (
 					<span class="font-semibold text-gray-900 dark:text-gray-50" aria-current="true">EN</span>
 				)
@@ -110,14 +112,14 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 				isZh ? (
 					<span class="font-semibold text-gray-900 dark:text-gray-50" aria-current="true">中文</span>
 				) : (
-					<a class="header-item text-gray-700 no-underline transition-colors duration-200 ease-out hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-50" href={zhHref}>中文</a>
+					<a class="link-line" href={zhHref}>中文</a>
 				)
 			}
 		</span>
 		{/* 主题平铺切换：图标按钮，dark ↔ light 翻转；dark 下显示 sun（点击转 light），反之显示 moon。 */}
 		<button
 			type="button"
-			class="theme-toggle header-item inline-flex items-center p-1 text-gray-700 transition-colors duration-200 ease-out hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-50"
+			class="theme-toggle inline-flex items-center p-1 text-gray-700 transition-colors duration-200 ease-out hover:text-accent-600 dark:text-gray-300 dark:hover:text-accent-400"
 			data-theme-toggle
 			aria-label={themeLabel}
 		>
@@ -142,6 +144,19 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 </script>
 
 <style>
+	/* active 导航链接下划线常显（.link-line 基元的 ::after），其余时刻 hover/focus 生长。 */
+	.header-nav-link.is-active::after {
+		transform: scaleX(1);
+	}
+
+	/* aukcraft 居中容器：scoped .header 规则带作用域属性选择器，特异性高于
+	 * utilities 层的 max-w-5xl / mx-auto，故在此同作用域覆写（max-w-5xl 工具类
+	 * 仍保留在 class 上作语义标注，实际生效值以此处为准）。 */
+	.header {
+		max-width: var(--container-5xl);
+		margin-inline: auto;
+	}
+
 	@layer starlight.core {
 		.header {
 			display: flex;

--- a/docs/src/styles/starlight-polish.css
+++ b/docs/src/styles/starlight-polish.css
@@ -205,12 +205,12 @@ site-search button[data-open-modal] {
 
   site-search button[data-open-modal]:hover {
     border-color: transparent;
-    color: var(--sl-color-white);
+    color: var(--sl-color-text-accent);
   }
 }
 
 site-search button[data-open-modal]:hover {
-  color: var(--sl-color-white);
+  color: var(--sl-color-text-accent);
 }
 
 /* 隐藏搜索按钮内的文字标签与快捷键提示（保留 aria-label 无障碍语义）。 */

--- a/docs/src/styles/starlight-polish.css
+++ b/docs/src/styles/starlight-polish.css
@@ -179,44 +179,49 @@
  * 10. 控件覆写：搜索框 / 主题切换（D7）
  * --------------------------------------------------------- */
 
-/* 搜索触发按钮：图标按钮化（aukcraft 平铺头栏）——去边框/底色，隐藏文字标签
- * 与 ⌘K kbd，仅保留放大镜图标；hover 与头栏链接同一颜色过渡（200ms）。
+/* 搜索触发按钮：.flight 方形 hairline 按钮化（与其他按钮同一形态）——
+ * hairline 边框 + 4px 圆角 + FlightLine 描边动效（SVG 由 Header.astro 脚本注入
+ * .flight / .flight-line class，动画规则在 global.css 基元中，完全一致）。
+ * 显示放大镜图标 + 快捷键 kbd 提示，隐藏 "Search" 文字标签（保留 aria-label）。
  * 目标：@astrojs/starlight 0.41；内部 class：site-search button[data-open-modal]
  * （Search.astro 内联样式，桌面断点 50rem 下声明 border/background/width）。 */
 site-search button[data-open-modal] {
-  border: 0;
+  border: 1px solid var(--sl-color-hairline);
   border-radius: 4px;
-  background: transparent;
+  background: var(--sl-color-bg-sidebar);
   width: auto;
   max-width: none;
   height: auto;
-  padding: 0.25rem;
+  padding: 0.375rem 0.625rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   color: var(--sl-color-gray-2);
-  transition: color 200ms ease;
 }
 
 @media (min-width: 50rem) {
-  /* 桌面断点下 Starlight 默认声明了 border/background/padding，需同级覆写。 */
+  /* 桌面断点下 Starlight 默认声明了 border/background/padding/max-width，需同级覆写。 */
   site-search button[data-open-modal] {
-    border: 0;
-    background: transparent;
-    padding: 0.25rem;
+    border: 1px solid var(--sl-color-hairline);
+    background: var(--sl-color-bg-sidebar);
+    padding: 0.375rem 0.625rem;
+    max-width: none;
   }
 
   site-search button[data-open-modal]:hover {
-    border-color: transparent;
-    color: var(--sl-color-text-accent);
+    border-color: var(--sl-color-hairline);
+    color: var(--sl-color-gray-1);
   }
 }
 
-site-search button[data-open-modal]:hover {
-  color: var(--sl-color-text-accent);
+/* 隐藏 "Search" 文字标签（图标 + kbd 已足够表意）；kbd 快捷键提示保持可见。 */
+site-search button[data-open-modal] > span {
+  display: none;
 }
 
-/* 隐藏搜索按钮内的文字标签与快捷键提示（保留 aria-label 无障碍语义）。 */
-site-search button[data-open-modal] > span,
+/* kbd 快捷键提示：行内小元素 2px 圆角（全站圆角体系）。 */
 site-search button[data-open-modal] > kbd {
-  display: none;
+  border-radius: 2px;
 }
 
 /* 搜索对话框：阴影已由 --sl-shadow-lg: none 清零，此处将 Pagefind 结果区圆角

--- a/docs/src/styles/starlight-polish.css
+++ b/docs/src/styles/starlight-polish.css
@@ -25,6 +25,9 @@
  * margin/max-width 节奏声明，见该节注释）。
  */
 
+/* 使本文件的 @apply 可解析 Tailwind 工具类（v4 独立 CSS 文件需显式 @reference 主题）。 */
+@reference 'tailwindcss';
+
 /* -----------------------------------------------------------
  * 1. 正文排版节奏
  * --------------------------------------------------------- */
@@ -184,44 +187,36 @@
  * .flight / .flight-line class，动画规则在 global.css 基元中，完全一致）。
  * 显示放大镜图标 + 快捷键 kbd 提示，隐藏 "Search" 文字标签（保留 aria-label）。
  * 目标：@astrojs/starlight 0.41；内部 class：site-search button[data-open-modal]
- * （Search.astro 内联样式，桌面断点 50rem 下声明 border/background/width）。 */
+ * （Search.astro 内联样式，桌面断点 50rem 下声明 border/background/width）。
+ * 该元素由 Starlight 内部组件渲染、无法挂工具类，故以 @apply 保持 utilities 表达。 */
 site-search button[data-open-modal] {
-  border: 1px solid var(--sl-color-hairline);
-  border-radius: 4px;
-  background: var(--sl-color-bg-sidebar);
+  @apply inline-flex items-center gap-2 rounded border border-(--sl-color-hairline) bg-(--sl-color-bg-sidebar) px-2.5 py-1.5 text-gray-700 dark:text-gray-300;
+  /* Starlight 默认 width/max-width/height 约束搜索框形态，按钮化需放开（无对应工具类，保留声明）。 */
   width: auto;
   max-width: none;
   height: auto;
-  padding: 0.375rem 0.625rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--sl-color-gray-2);
 }
 
 @media (min-width: 50rem) {
   /* 桌面断点下 Starlight 默认声明了 border/background/padding/max-width，需同级覆写。 */
   site-search button[data-open-modal] {
-    border: 1px solid var(--sl-color-hairline);
-    background: var(--sl-color-bg-sidebar);
-    padding: 0.375rem 0.625rem;
+    @apply border-(--sl-color-hairline) bg-(--sl-color-bg-sidebar) px-2.5 py-1.5;
     max-width: none;
   }
 
   site-search button[data-open-modal]:hover {
-    border-color: var(--sl-color-hairline);
-    color: var(--sl-color-gray-1);
+    @apply text-gray-900 dark:text-gray-50;
   }
 }
 
 /* 隐藏 "Search" 文字标签（图标 + kbd 已足够表意）；kbd 快捷键提示保持可见。 */
 site-search button[data-open-modal] > span {
-  display: none;
+  @apply hidden;
 }
 
 /* kbd 快捷键提示：行内小元素 2px 圆角（全站圆角体系）。 */
 site-search button[data-open-modal] > kbd {
-  border-radius: 2px;
+  @apply rounded-xs;
 }
 
 /* 搜索对话框：阴影已由 --sl-shadow-lg: none 清零，此处将 Pagefind 结果区圆角


### PR DESCRIPTION
## 背景

PR #69（header-aukcraft-nav）在这三个提交推送**之前**被 squash 合并（main 上为 \`d15fafa\`），导致以下变更未进 main。本 PR 基于最新 main cherry-pick 补录：

- \`487862a\` 头栏容器 max-w-5xl 居中 + 所有链接统一 .link-line 下划线（同 footer 基元，active 常显）
- \`be99627\` 搜索改 .flight 按钮（hairline + FlightLine 描边，与其他按钮同效）+ 快捷键 kbd 提示（Ctrl K / ⌘K）
- \`6263a0d\` 覆写回归 Tailwind utilities（\`max-w-5xl!\` / \`after:[...]!\` / 搜索按钮 \`@apply\`）

## 验收

- 头栏 1024px 居中实测生效；导航 link-line 下划线 hover 生长、active 常显；搜索按钮 flight-trace 描边动画触发、kbd 可见。
- main 基底上 \`npm run build && npm run verify\` 全绿（明暗 / 双语 / 移动 / reduced-motion）。

属 #69 的收尾补录，无新 OpenSpec change。

> ⚠️ 建议：合并前请先确认 PR 的提交已全部推送（本 PR 为 3 个提交，HEAD \`6263a0d\`）。