### PR TITLE
fix(ci): opencode 仅响应显式 /oc /opencode 召唤，阻断自回复循环

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -12,8 +12,13 @@ on:
 
 jobs:
   opencode:
+    # 仅显式召唤时运行：人类评论且以 /oc 或 /opencode 开头。
+    # 关键防环：opencode 自身以 Bot 身份回帖，user.type != 'Bot' 保证
+    # agent 永远不会被自己的评论再次触发（此前 #80 即因此自激励循环）。
     if: |
-      github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment'
+      (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
+      github.event.comment.user.type != 'Bot' &&
+      (startsWith(github.event.comment.body, '/oc') || startsWith(github.event.comment.body, '/opencode'))
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## 问题

issue #80 上 opencode agent 回复自己的评论后，`issue_comment` 触发器不区分评论者身份，agent 的自回复又触发了新一轮运行，形成 /oc 自激励循环刷屏。

## 修复

收紧 `opencode`（评论回复）job 的触发条件：

- 评论者 `user.type != 'Bot'`（关键防环：agent 以 Bot 身份回帖，永远不会再触发自己）
- 评论以 `/oc` 或 `/opencode` 开头（仅显式召唤才运行）

`auto-label`（新 issue/PR 自动打标签）与 `auto-translate`（translation 标签翻译闭环）不受影响——它们不监听评论、不会自激励。

## 自查

- [x] 仅修改 `.github/workflows/opencode.yml` 的 `opencode` job `if` 条件
- [x] 不影响 auto-label / auto-translate（community-translation-pipeline 行为不变）
- [x] 合并即生效，#80 上的循环在下一条评论后停止
