### PR TITLE
fix(ci): 按改动面分流 CI 与 Snapshot 触发

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 
-# 每次 push 到 main/master/dev 分支或提交 PR 时触发，
-# 验证 Windows 平台编译与测试通过。
+# 每次 push 到 main/master/dev 分支或提交 PR 时触发，验证 Windows 平台编译与测试通过。
+# 通过 changes job（dorny/paths-filter）按改动面分流：Rust 改动才跑
+# build/test-report/lint，前端改动才跑 frontend-report，locale 改动才跑
+# i18n-check，版本/changelog 改动才跑 docs-consistency——纯文档 /
+# OpenSpec 工件 PR 不再空转全量 CI。
 on:
   push:
     branches: [main, master, dev]
@@ -12,9 +15,53 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # 改动面探测：按 PR / push 的文件变更分类，供下游 job 的 if 分流。
+  # push 事件与最近一次 push 的 commit 比较，同样生效（main 上的纯文档
+  # 提交不会跑重型 job）。
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      i18n: ${{ steps.filter.outputs.i18n }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Path filter
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'src-tauri/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            frontend:
+              - 'src/**'
+              - 'index.html'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'vite.config.ts'
+              - 'tsconfig.json'
+              - 'tailwind.config.ts'
+              - 'postcss.config.*'
+              - 'components.json'
+            i18n:
+              - 'src/i18n/**'
+            docs:
+              - 'package.json'
+              - 'docs/src/content/docs/guide/changelog.md'
   # 跨平台编译检查（不打包，只确保能 build）。
   build:
     name: Build & Test (${{ matrix.target }})
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -52,6 +99,8 @@ jobs:
   # 完整测试套件（Windows runner）：生成 JUnit XML 测试报告
   test-report:
     name: Test Report (Windows)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -123,6 +172,8 @@ jobs:
   # 前端测试与构建报告
   frontend-report:
     name: Frontend Report
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -164,6 +215,8 @@ jobs:
   # 代码格式与 lint 检查（仅在 Linux 上跑，节省 CI 时间）。
   lint:
     name: Lint (fmt + clippy)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -201,9 +254,10 @@ jobs:
   # 详见 scripts/check-i18n.mjs。失败阻塞 merge（与人工 review 并行，纯增益）。
   i18n-check:
     name: i18n Check
+    needs: changes
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'pull_request' &&
+      needs.changes.outputs.i18n == 'true' &&
       !cancelled()
     steps:
       - name: Checkout
@@ -227,6 +281,8 @@ jobs:
   # release.yml 的 verify-docs 闸门（tag 推送时）才是最终强制。
   docs-consistency:
     name: Docs Consistency
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -257,7 +313,7 @@ jobs:
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
-    needs: [build, test-report, frontend-report, lint, i18n-check, docs-consistency]
+    needs: [changes, build, test-report, frontend-report, lint, i18n-check, docs-consistency]
     if: always()
     steps:
       - name: Check all jobs status

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,6 +8,26 @@ name: Snapshot
 on:
   pull_request:
     branches: [main, master, dev]
+    # 仅当代码 / 依赖 / 构建配置变化时才触发快照构建（三架构 NSIS+zip 成本高）。
+    # 文档（docs/）、OpenSpec 工件（openspec/）、纯 markdown、与产物无关的
+    # workflow 改动不触发——避免如「改一行 CI 注释也要等 7 分钟快照」。
+    # 手动 workflow_dispatch 不受 paths 限制，随时可强制构建。
+    paths:
+      - 'crates/**'
+      - 'src/**'
+      - 'src-tauri/**'
+      - 'assets/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'index.html'
+      - 'vite.config.ts'
+      - 'tsconfig.json'
+      - 'tailwind.config.ts'
+      - 'postcss.config.*'
+      - 'components.json'
+      - '.github/workflows/snapshot.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,8 +10,8 @@ on:
     branches: [main, master, dev]
     # 仅当代码 / 依赖 / 构建配置变化时才触发快照构建（三架构 NSIS+zip 成本高）。
     # 文档（docs/）、OpenSpec 工件（openspec/）、纯 markdown、与产物无关的
-    # workflow 改动不触发——避免如「改一行 CI 注释也要等 7 分钟快照」。
-    # 手动 workflow_dispatch 不受 paths 限制，随时可强制构建。
+    # workflow 改动（含本文件自身）不触发——避免如「改一行 CI 注释也要等
+    # 7 分钟快照」。需要验证快照构建时用 workflow_dispatch 手动触发。
     paths:
       - 'crates/**'
       - 'src/**'
@@ -27,7 +27,6 @@ on:
       - 'tailwind.config.ts'
       - 'postcss.config.*'
       - 'components.json'
-      - '.github/workflows/snapshot.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 问题

所有 PR 无条件触发全量 CI + Snapshot：纯文档 / OpenSpec / workflow 注释改动（如 #82）也要等待三架构约 7 分钟的快照构建，CI 队列混乱。

## 修复

**snapshot.yml**（workflow 级 `paths` 过滤）：
- 仅 `crates/**`、`src/**`、`src-tauri/**`、`assets/**`、依赖清单（Cargo/package）、构建配置（vite/ts/tailwind）等影响产物的路径触发
- `workflow_dispatch` 不受限，随时可强制构建

**ci.yml**（新增 `changes` job，dorny/paths-filter v3 分流）：

| job | 触发条件 |
|-----|---------|
| build | rust ∥ frontend |
| test-report / lint | rust |
| frontend-report | frontend |
| i18n-check | src/i18n/** |
| docs-consistency | package.json ∥ changelog |
| quality-gate | 不变（原逻辑只对 `failure` 失败，skipped 天然兼容） |

## 注意事项

- 若分支保护把这些 job 设为 required check：skipped 结论会被 GitHub 视为满足（dorny 官方推荐用法）
- push 到 main 的纯文档提交同样跳过重型 job（与 PR 行为一致）

## 自查

- [x] snapshot 仅受代码路径触发，手动触发不受影响
- [x] ci 六个 job 均按改动面分流，quality-gate 判定逻辑未改动
- [x] 本 PR 自身命中 `.github/workflows/**` 不在快照 paths 内 → 不触发 Snapshot（即自我验证）
