### PR TITLE
style: cargo fmt 修复 refresh_materials 格式

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1718,9 +1718,11 @@ fn refresh_materials(
     );
 
     // 与 watcher 重载路径相同的两路通知：overlay 换 registry + 前端广播。
-    let _ = state.overlay_cmd_tx.send(overlay::OverlayCommand::RefreshMaterials(
-        Arc::new(state.material_registry.clone()),
-    ));
+    let _ = state
+        .overlay_cmd_tx
+        .send(overlay::OverlayCommand::RefreshMaterials(Arc::new(
+            state.material_registry.clone(),
+        )));
     if let Err(e) = app.emit("peregrine:materials-changed", ()) {
         tracing::warn!(error = %e, "emit materials-changed failed");
     }


### PR DESCRIPTION
## 变更摘要

PR #85 的 be1d086 提交遗漏 cargo fmt（CI Lint job 失败于 Cargo fmt check 步骤）。本 PR 仅格式化 `refresh_materials` 中的一处链式调用，无任何逻辑改动，为 v0.2.8 发版的前置修复。

## 变更类型

- [ ] 新功能（feature）
- [ ] bug 修复（bugfix）
- [ ] 重构（refactor）
- [ ] 文档（docs）
- [ ] 构建 / CI（build）
- [x] 其它

## 自检清单

- [x] `cargo fmt --all -- --check` 通过
- [x] 无逻辑改动（纯格式）