### PR TITLE
feat(docs): 文档站新增 .rhai 物料编辑器 /playground

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -20,6 +20,7 @@ const sidebar = [
   },
   { label: 'Docs', translations: { 'zh-CN': '文档' }, slug: 'guide/intro' },
   { label: 'Download', translations: { 'zh-CN': '下载' }, slug: 'download' },
+  { label: 'Playground', translations: { 'zh-CN': '编辑器' }, slug: 'playground' },
   {
     label: 'Guide',
     translations: { 'zh-CN': '指南' },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -80,10 +80,13 @@ export default defineConfig({
       sidebar,
       customCss: ['./src/styles/global.css', './src/styles/starlight-polish.css'],
       // 仅覆写 Hero（首页落地页化）与 Header（顶部导航链接，仅插入导航区、其余结构不动）。
-      // 不增加其他覆写，降低升级脆弱性；Header 覆写理由与维护注意见 AGENTS.md。
+      // 仅覆写 Hero（首页落地页化）、Header（顶部导航链接，仅插入导航区、其余结构不动）
+      // 与 ThemeProvider（缺省主题改为 dark，尊重用户显式切换）。
+      // 不增加其他覆写，降低升级脆弱性；各覆写理由与维护注意见 AGENTS.md。
       components: {
         Hero: './src/components/landing/LandingHero.astro',
         Header: './src/components/Header.astro',
+        ThemeProvider: './src/components/ThemeProvider.astro',
       },
       // 「在 GitHub 上编辑此页面」链接（Starlight 自动拼接 src/content/docs 相对路径并适配双语子目录）。
       editLink: {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,9 +10,13 @@
       "dependencies": {
         "@astrojs/starlight": "^0.41.7",
         "@astrojs/starlight-tailwind": "^5.0.0",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/state": "^6.7.4",
+        "@codemirror/view": "^6.43.11",
         "@fontsource-variable/newsreader": "^5.2.5",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.2.1",
+        "codemirror": "^6.0.2",
         "mermaid": "^11.17.0",
         "starlight-llms-txt": "^0.11.0",
         "tailwindcss": "^4.3.3"
@@ -762,6 +766,87 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.11.0.tgz",
+      "integrity": "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.2.tgz",
+      "integrity": "sha512-gUYkYhT2+n/+VGZ+8EzE5WFkYZUZYm1VOKDudIsNqh42uRVQJ0a6Yss9sdKT3MeOYfuL1N6AZA57oza0Oyr0LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.4.tgz",
+      "integrity": "sha512-QhQIVRY+xHZDxwOSFrJ1eUMapJBUID3IdeAjf7dHO7zBUzSkyooHiodnalz5MG3iHzwixKMlAAyn7244y537EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.11.tgz",
+      "integrity": "sha512-2+esucbQX6wB2JYi1eDvdCPFTA31BN8oSy6xCmk3G6CloV11yOvEjYk+gH7kLrP0MuHG94E8WDhjs5oMiu3+Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -1858,6 +1943,36 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.4.tgz",
+      "integrity": "sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==",
+      "license": "MIT"
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
@@ -3667,6 +3782,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
@@ -3728,6 +3858,12 @@
       "dependencies": {
         "layout-base": "^1.0.0"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
     },
     "node_modules/crossws": {
       "version": "0.3.5",
@@ -7923,6 +8059,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -8543,6 +8685,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,14 +8,19 @@
     "build": "astro build",
     "preview": "astro preview",
     "screenshots": "node scripts/capture-screenshots.mjs",
+    "smoke:playground": "node scripts/smoke-playground.mjs",
     "verify": "node scripts/verify-landing.mjs && node scripts/verify-polish.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.7",
     "@astrojs/starlight-tailwind": "^5.0.0",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/state": "^6.7.4",
+    "@codemirror/view": "^6.43.11",
     "@fontsource-variable/newsreader": "^5.2.5",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.1",
+    "codemirror": "^6.0.2",
     "mermaid": "^11.17.0",
     "starlight-llms-txt": "^0.11.0",
     "tailwindcss": "^4.3.3"

--- a/docs/scripts/smoke-playground.mjs
+++ b/docs/scripts/smoke-playground.mjs
@@ -1,0 +1,52 @@
+// 临时冒烟脚本：验证 /playground 页 CodeMirror 初始化、模板切换、校验与下载按钮存在。
+// 用法：node docs/scripts/smoke-playground.mjs（需先 npm run build）
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize } from 'node:path';
+import { chromium } from 'playwright';
+
+const root = join(process.cwd(), 'dist');
+const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.svg': 'image/svg+xml', '.json': 'application/json' };
+const server = createServer(async (req, res) => {
+  try {
+    let p = join(root, decodeURIComponent(req.url.split('?')[0]).replace(/\/$/, '/index.html').replace(/^\//, '') || 'index.html');
+    if (p.endsWith('/')) p += 'index.html';
+    const data = await readFile(normalize(p));
+    res.writeHead(200, { 'content-type': mime[extname(p)] ?? 'application/octet-stream' });
+    res.end(data);
+  } catch {
+    res.writeHead(404);
+    res.end('not found');
+  }
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push(String(e)));
+await page.goto(`http://127.0.0.1:${port}/playground.html`);
+
+const hasEditor = await page.locator('.pg-editor .cm-editor').count();
+const checks = await page.locator('.pg-checks li').count();
+console.log('cm-editor:', hasEditor > 0 ? 'OK' : 'MISSING');
+console.log('checks rendered:', checks, checks > 0 ? 'OK' : 'MISSING');
+
+// 模板切换：切到 呼吸圆点，期望 is_dynamic 出现在文档中。
+await page.click('.pg-tpl[data-tpl="breath"]');
+await page.waitForTimeout(200);
+const docHasDyn = await page.locator('.cm-content', { hasText: 'is_dynamic' }).count();
+console.log('template switch:', docHasDyn > 0 ? 'OK' : 'FAIL');
+
+// 破坏脚本：删掉 build 函数行，期望错误检查出现。
+await page.click('.pg-editor .cm-content');
+await page.keyboard.press('Control+A');
+await page.keyboard.type('// Name: broken\nfn defaults() { #{} }\nfn schema() { [] }\n', { delay: 5 });
+await page.waitForTimeout(200);
+const errCount = await page.locator('.pg-checks li', { hasText: 'build' }).count();
+console.log('missing build detected:', errCount > 0 ? 'OK' : 'FAIL');
+
+console.log('page errors:', errors.length === 0 ? 'none' : errors.join(' | '));
+await browser.close();
+server.close();

--- a/docs/scripts/verify-landing.mjs
+++ b/docs/scripts/verify-landing.mjs
@@ -30,6 +30,9 @@ const check = (label, cond, detail = '') => {
 for (const theme of ['dark', 'light']) {
   for (const [name, url] of [['en', '/'], ['zh', '/zh-cn']]) {
     const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, colorScheme: theme });
+    // 站点缺省主题已改为 dark（ThemeProvider 覆写），不再跟随 prefers-color-scheme；
+    // 用 localStorage 显式设定主题（与顶栏切换同一协议）来驱动 dark/light 两轮验收。
+    await ctx.addInitScript((t) => localStorage.setItem('starlight-theme', t), theme);
     const page = await ctx.newPage();
     await page.goto('http://localhost:4399' + url, { waitUntil: 'networkidle' });
     const r = await page.evaluate(() => {
@@ -457,6 +460,9 @@ for (const theme of ['dark', 'light']) {
     ['zh', '/zh-cn/download', true],
   ]) {
     const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, colorScheme: theme });
+    // 站点缺省主题已改为 dark（ThemeProvider 覆写），不再跟随 prefers-color-scheme；
+    // 用 localStorage 显式设定主题（与顶栏切换同一协议）来驱动 dark/light 两轮验收。
+    await ctx.addInitScript((t) => localStorage.setItem('starlight-theme', t), theme);
     const page = await ctx.newPage();
     await page.goto('http://localhost:4399' + url, { waitUntil: 'networkidle' });
     const r = await page.evaluate(() => {

--- a/docs/scripts/verify-landing.mjs
+++ b/docs/scripts/verify-landing.mjs
@@ -287,11 +287,12 @@ for (const theme of ['dark', 'light']) {
       JSON.stringify(r.dlButtons),
     );
     check(
-      `${t} 顶栏导航 3 链接（Docs/Download/GitHub）`,
-      r.headerNav.length === 3 &&
+      `${t} 顶栏导航 4 链接（Docs/Download/Playground/GitHub）`,
+      r.headerNav.length === 4 &&
         r.headerNav[0].endsWith('/guide/intro') &&
         r.headerNav[1].endsWith('/download') &&
-        r.headerNav[2] === 'https://github.com/eeymoo/peregrine',
+        r.headerNav[2].endsWith('/playground') &&
+        r.headerNav[3] === 'https://github.com/eeymoo/peregrine',
       JSON.stringify(r.headerNav),
     );
     check(`${t} 顶栏保留`, r.topbar === true);

--- a/docs/scripts/verify-polish.mjs
+++ b/docs/scripts/verify-polish.mjs
@@ -35,6 +35,8 @@ const check = (label, cond, detail) => {
 for (const theme of ['dark', 'light']) {
   for (const [name, url] of [['en', PAGES.table[0]], ['zh', PAGES.table[1]]]) {
     const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, colorScheme: theme });
+    // 站点缺省主题为 dark（不跟随系统）；用 localStorage 显式设定主题驱动验收。
+    await ctx.addInitScript((t) => localStorage.setItem('starlight-theme', t), theme);
     const page = await ctx.newPage();
     await page.goto('http://localhost:4399' + url, { waitUntil: 'networkidle' });
     const r = await page.evaluate(() => {
@@ -73,6 +75,8 @@ for (const theme of ['dark', 'light']) {
   // aside / 正文链接在 usage 页校验（config 页不含这两种元素）。
   for (const [name, url] of [['en', PAGES.aside[0]], ['zh', PAGES.aside[1]]]) {
     const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, colorScheme: theme });
+    // 站点缺省主题为 dark（不跟随系统）；用 localStorage 显式设定主题驱动验收。
+    await ctx.addInitScript((t) => localStorage.setItem('starlight-theme', t), theme);
     const page = await ctx.newPage();
     await page.goto('http://localhost:4399' + url, { waitUntil: 'networkidle' });
     const r = await page.evaluate(() => {

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -44,6 +44,7 @@ const prefix = locale ? `/${locale}` : '';
 const navLinks = [
 	{ label: locale ? '文档' : 'Docs', href: `${prefix}/guide/intro`, external: false },
 	{ label: locale ? '下载' : 'Download', href: `${prefix}/download`, external: false },
+	{ label: locale ? '编辑器' : 'Playground', href: `${prefix}/playground`, external: false },
 	{ label: 'GitHub', href: 'https://github.com/eeymoo/peregrine', external: true },
 ];
 // 当前页 active 态。路由判定最小化——pathname 去掉可选 .html 后缀与尾斜杠后前缀比较。

--- a/docs/src/components/ThemeProvider.astro
+++ b/docs/src/components/ThemeProvider.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * Starlight `ThemeProvider` 覆写：默认主题改为 dark（黑色）。
+ *
+ * 与上游 @astrojs/starlight 0.41 的 components/ThemeProvider.astro 同构，改动两处：
+ * 1. 无 localStorage 记录时不跟随 prefers-color-scheme，缺省 dark；
+ * 2. 删除 `#theme-icons` 模板与 Icon 依赖——原生 ThemeSelect 仅存在于默认 Header，
+ *    本站 Header 已覆写为自带 sun/moon 切换，页面上不存在 starlight-theme-select，
+ *    updatePickers 的图标替换分支保持空转（原有 null 守卫已兼容）。
+ * 用户通过顶栏切换（写 localStorage `starlight-theme`）后仍尊重其显式选择。
+ *
+ * 维护注意：升级 Starlight 时，请 diff 上游 ThemeProvider.astro 并重新同步
+ * （上游在该文件标注 "intentionally inlined to avoid FOUC"，勿改为非内联脚本）。
+ */
+---
+
+{/* This is intentionally inlined to avoid FOUC. */}
+<script is:inline>
+	window.StarlightThemeProvider = (() => {
+		const storedTheme =
+			typeof localStorage !== 'undefined' && localStorage.getItem('starlight-theme');
+		// 唯一行为改动：缺省主题为 dark（原上游实现为跟随 prefers-color-scheme）。
+		const theme = storedTheme || 'dark';
+		document.documentElement.dataset.theme = theme === 'light' ? 'light' : 'dark';
+		return {
+			updatePickers(theme = storedTheme || 'auto') {
+				document.querySelectorAll('starlight-theme-select').forEach((picker) => {
+					const select = picker.querySelector('select');
+					if (select) select.value = theme;
+					/** @type {HTMLTemplateElement | null} */
+					const tmpl = document.querySelector(`#theme-icons`);
+					const newIcon = tmpl && tmpl.content.querySelector('.' + theme);
+					if (newIcon) {
+						const oldIcon = picker.querySelector('svg.label-icon');
+						if (oldIcon) {
+							oldIcon.replaceChildren(...newIcon.cloneNode(true).childNodes);
+						}
+					}
+				});
+			},
+		};
+	})();
+</script>

--- a/docs/src/components/playground/RhaiPlayground.astro
+++ b/docs/src/components/playground/RhaiPlayground.astro
@@ -1,0 +1,404 @@
+---
+/**
+ * Rhai 物料编辑器（/playground 页核心组件）
+ *
+ * 纯前端实现：CodeMirror 6 语法高亮（自定义 Rhai StreamLanguage）+
+ * 契约静态校验（必需函数 / widget 与图元白名单 / 动态声明一致性）+
+ * 模板库 + 一键下载 .rhai / 复制。不在浏览器内求值——真实求值由应用
+ * 热加载后完成（写入 materials/ 目录即自动生效，见右侧安装提示）。
+ *
+ * 主题：aukcraft 壳层语法（1px 发丝线、4px 圆角、零阴影、灰阶承面），
+ * CodeMirror 配色通过 var(--color-gray-*) / var(--color-accent-*) 引用
+ * @theme tokens，明暗随 <html data-theme> 自动切换。
+ *
+ * 用法（.mdx 页面）：
+ *   import RhaiPlayground from '../../../components/playground/RhaiPlayground.astro';
+ *   <RhaiPlayground locale="zh-cn" />
+ */
+interface Props {
+  /** 语言：'en' | 'zh-cn'（控制 UI 文案） */
+  locale: 'en' | 'zh-cn';
+}
+
+const { locale } = Astro.props;
+const zh = locale === 'zh-cn';
+
+const i18n = {
+  editorLabel: zh ? '物料编辑器' : 'Material Editor',
+  templates: zh ? '模板' : 'Templates',
+  tplCross: zh ? '简易十字' : 'Simple Cross',
+  tplBreath: zh ? '呼吸圆点' : 'Breathing Dot',
+  tplPath: zh ? 'SVG 路径' : 'SVG Path',
+  download: zh ? '下载 .rhai' : 'Download .rhai',
+  copy: zh ? '复制' : 'Copy',
+  copied: zh ? '已复制' : 'Copied',
+  filename: zh ? '文件名' : 'File name',
+  validation: zh ? '契约校验' : 'Contract checks',
+  install: zh ? '安装到 Peregrine' : 'Install to Peregrine',
+  installBody: zh
+    ? '下载后把 .rhai 文件放入应用数据目录的 materials/ 文件夹（设置 → 物料页有「打开物料目录」按钮），约 500ms 自动热加载，然后在 设置 → 图层 添加 user.<文件名>。'
+    : 'Drop the downloaded .rhai into the materials/ folder of the app data directory (Settings → Materials has an "Open materials folder" button). It hot-reloads in ~500ms; then add user.<filename> in Settings → Layers.',
+  docsLink: zh ? '完整脚本指南' : 'Full scripting guide',
+  reset: zh ? '重置' : 'Reset',
+};
+
+// 三份内置模板（与文档站脚本指南 / crates/material/examples 同源，精简版）。
+const templates: Record<string, { label: string; name: string; source: string }> = {
+  cross: {
+    label: i18n.tplCross,
+    name: 'my_cross',
+    source: `// Name: ${i18n.tplCross}
+fn defaults() {
+    #{ arm_length: 20.0, thickness: 3.0, gap: 4.0 }
+}
+fn schema() {
+    [
+        #{key: "arm_length", label: "${zh ? '臂长' : 'Arm'}", widget: "slider", min: 1.0, max: 200.0, step: 1.0},
+        #{key: "thickness", label: "${zh ? '粗细' : 'Thickness'}", widget: "slider", min: 0.5, max: 20.0, step: 0.5},
+        #{key: "gap", label: "${zh ? '间隙' : 'Gap'}", widget: "slider", min: 0.0, max: 40.0, step: 1.0},
+    ]
+}
+fn build(params, screen) {
+    let arm = params.arm_length;
+    let t = params.thickness;
+    let g = params.gap / 2.0;
+    let cx = (screen.min_x + screen.max_x) / 2.0;
+    let cy = (screen.min_y + screen.max_y) / 2.0;
+    [
+        #{type: "rect", x: cx - arm, y: cy - t / 2.0, w: arm - g, h: t},
+        #{type: "rect", x: cx + g, y: cy - t / 2.0, w: arm - g, h: t},
+        #{type: "rect", x: cx - t / 2.0, y: cy - arm, w: t, h: arm - g},
+        #{type: "rect", x: cx - t / 2.0, y: cy + g, w: t, h: arm - g},
+    ]
+}
+`,
+  },
+  breath: {
+    label: i18n.tplBreath,
+    name: 'breathing_dot',
+    source: `// Name: ${i18n.tplBreath}
+fn defaults() {
+    #{ radius: 12.0, breathe_pct: 8.0, period_ms: 4200.0 }
+}
+fn schema() {
+    [
+        #{key: "radius", label: "${zh ? '半径' : 'Radius'}", widget: "slider", min: 2.0, max: 80.0, step: 1.0},
+        #{key: "breathe_pct", label: "${zh ? '涨缩幅度 %' : 'Breathe %'}", widget: "slider", min: 1.0, max: 30.0, step: 1.0},
+        #{key: "period_ms", label: "${zh ? '周期 ms' : 'Period ms'}", widget: "number", min: 500.0, max: 20000.0, step: 100.0},
+    ]
+}
+fn is_dynamic() { true }
+fn refresh_interval_ms() { 50 }
+fn build(params, screen) {
+    let cx = (screen.min_x + screen.max_x) / 2.0;
+    let cy = (screen.min_y + screen.max_y) / 2.0;
+    let phase = (time_ms() % params.period_ms) / params.period_ms;
+    let scale = 1.0 + params.breathe_pct / 100.0 * sin(phase * 6.28318);
+    let r = params.radius * scale;
+    [ #{type: "circle", cx: cx, cy: cy, radius: r} ]
+}
+`,
+  },
+  path: {
+    label: i18n.tplPath,
+    name: 'svg_anchor',
+    source: `// Name: ${i18n.tplPath}
+fn defaults() {
+    #{ size: 40.0, d: "M 0 -10 Q 10 0 0 10 Q -10 0 0 -10 Z" }
+}
+fn schema() {
+    [
+        #{key: "size", label: "${zh ? '大小' : 'Size'}", widget: "slider", min: 8.0, max: 200.0, step: 1.0},
+        #{key: "d", label: "SVG path d", widget: "text"},
+    ]
+}
+fn build(params, screen) {
+    let cx = (screen.min_x + screen.max_x) / 2.0;
+    let cy = (screen.min_y + screen.max_y) / 2.0;
+    let segs = parse_svg_path(params.d);
+    if segs.len() == 0 {
+        segs = parse_svg_path("M 0 -10 Q 10 0 0 10 Q -10 0 0 -10 Z");
+    }
+    // 归一化到 [-0.5, 0.5] 再按 size 缩放、屏幕居中。
+    let bbox = path_bbox(segs);
+    let s = if bbox.2 > bbox.3 { bbox.2 } else { bbox.3 };
+    let scaled = [];
+    for seg in segs {
+        let m = #{};
+        m.cmd = seg.cmd;
+        if seg.cmd != "Z" {
+            m.x = cx + (seg.x - (bbox.0 + bbox.2) / 2.0) / s * params.size;
+            m.y = cy + (seg.y - (bbox.1 + bbox.3) / 2.0) / s * params.size;
+            if seg.cmd == "Q" {
+                m.x1 = cx + (seg.x1 - (bbox.0 + bbox.2) / 2.0) / s * params.size;
+                m.y1 = cy + (seg.y1 - (bbox.1 + bbox.3) / 2.0) / s * params.size;
+            }
+        }
+        scaled.push(m);
+    }
+    [ #{type: "path", segments: scaled, fill: true, thickness: 0.0} ]
+}
+`,
+  },
+};
+---
+
+<div
+  class="pg-root not-prose grid grid-cols-1 gap-px rounded border border-(--sl-color-hairline) bg-(--sl-color-hairline) md:grid-cols-[minmax(0,1.7fr)_minmax(260px,1fr)]"
+  data-locale={locale}
+>
+  <div class="bg-gray-50 p-4 sm:p-5 dark:bg-gray-950">
+    <div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+      <span class="font-mono text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">
+        {i18n.editorLabel}
+      </span>
+      <span class="pg-status font-mono text-xs text-gray-400 dark:text-gray-500"></span>
+      <span class="ml-auto flex items-center gap-2">
+        <label class="sr-only" for="pg-filename">{i18n.filename}</label>
+        <input
+          id="pg-filename"
+          class="pg-filename w-28 rounded-sm border border-(--sl-color-hairline) bg-transparent px-2 py-1 font-mono text-xs text-gray-700 dark:text-gray-300"
+          value={templates.cross.name}
+          spellcheck="false"
+        />
+        <span class="font-mono text-xs text-gray-400 dark:text-gray-500">.rhai</span>
+      </span>
+    </div>
+    <div class="pg-editor min-h-80 overflow-hidden rounded-sm border border-(--sl-color-hairline) bg-gray-100 dark:bg-gray-900"></div>
+    <div class="mt-3 flex flex-wrap items-center gap-2">
+      <span class="font-mono text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">
+        {i18n.templates}
+      </span>
+      {
+        Object.entries(templates).map(([key, tpl]) => (
+          <button
+            class="pg-tpl font-mono text-xs text-ink motion-safe:transition-colors hover:text-accent-600 dark:hover:text-accent-400"
+            data-tpl={key}
+            type="button"
+          >
+            {tpl.label}
+          </button>
+        ))
+      }
+      <button class="pg-reset ml-auto font-mono text-xs text-gray-500 hover:text-accent-600 dark:text-gray-400 dark:hover:text-accent-400" type="button">
+        {i18n.reset}
+      </button>
+    </div>
+  </div>
+
+  <div class="bg-gray-50 flex flex-col gap-4 p-4 sm:p-5 dark:bg-gray-950">
+    <div>
+      <h3 class="mb-2 font-mono text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">
+        {i18n.validation}
+      </h3>
+      <ul class="pg-checks space-y-1.5 text-sm"></ul>
+    </div>
+    <div>
+      <h3 class="mb-2 font-mono text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">
+        {i18n.install}
+      </h3>
+      <p class="text-sm leading-relaxed text-gray-600 dark:text-gray-300">{i18n.installBody}</p>
+    </div>
+    <div class="mt-auto flex flex-wrap gap-2">
+      <button
+        class="pg-download flight font-mono text-xs uppercase tracking-widest text-accent"
+        type="button"
+      >
+        {i18n.download}
+      </button>
+      <button
+        class="pg-copy link-line font-mono text-xs uppercase tracking-widest"
+        type="button"
+      >
+        {i18n.copy}
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  import { EditorState } from '@codemirror/state';
+  import { EditorView } from '@codemirror/view';
+  import { StreamLanguage } from '@codemirror/language';
+  import { basicSetup } from 'codemirror';
+
+  type Lang = 'en' | 'zh-cn';
+  const root = document.querySelector<HTMLElement>('.pg-root');
+  if (root) {
+    const lang = (root.dataset.locale as Lang) ?? 'en';
+    const zh = lang === 'zh-cn';
+    const t = {
+      ok: zh ? '通过' : 'pass',
+      warn: '注意'  ,
+      err: '错误',
+      needFn: (f: string) => zh ? `缺少必需函数 fn ${f}()` : `missing required fn ${f}()`,
+      nameHint: zh ? '首行 // Name: 缺失（显示名将取 id 末段）' : 'no // Name: on line 1 (display name falls back to id suffix)',
+      dynApi: zh ? '调用了动态 API 但 is_dynamic() 未声明 true' : 'dynamic APIs called but is_dynamic() is not true',
+      staticDyn: zh ? '声明为静态，但调用了动态 API（求值一次后冻结）' : 'declared static but calls dynamic APIs (frozen after first eval)',
+      badWidget: (w: string) => zh ? `未知 widget "${w}"` : `unknown widget "${w}"`,
+      badType: (ty: string) => zh ? `未知图元 type "${ty}"` : `unknown element type "${ty}"`,
+      schemaKey: (k: string) => zh ? `schema key "${k}" 在 defaults 中无默认值` : `schema key "${k}" has no default in defaults()`,
+      refreshHint: zh ? '动态物料建议声明 refresh_interval_ms() 节流' : 'consider refresh_interval_ms() to throttle a dynamic material',
+      allPass: zh ? '契约检查全部通过' : 'all contract checks passed',
+    };
+
+    /* ---------- Rhai 语法高亮（StreamLanguage 子集：注释/字符串/数字/关键字/map 括号） ---------- */
+    const rhaiLang = StreamLanguage.define({
+      token(stream) {
+        if (stream.match('//')) { stream.skipToEnd(); return 'comment'; }
+        if (stream.match(/^#[[{]/)) return 'bracket';
+        if (stream.match(/"(?:[^"\\]|\\.)*"/)) return 'string';
+        if (stream.match(/\d+\.\d+|\d+/)) return 'number';
+        if (stream.match(/`/)) { stream.skipToEnd(); return 'comment'; }
+        if (stream.match(/#[a-zA-Z_][\w!]*/)) return 'meta';
+        if (stream.match(/[a-zA-Z_][\w!]*/)) {
+          const kw = ['fn','let','if','else','while','loop','for','in','return','true','false','const','is','switch','do','break','continue','throw','try','catch','import','export','as','global','private','new'];
+          const w = stream.current();
+          if (kw.includes(w)) return 'keyword';
+          if (stream.peek() === '(') return 'variableName';
+          return 'propertyName';
+        }
+        stream.next();
+        return null;
+      },
+    });
+
+    /* ---------- 主题：引用 @theme tokens，随明暗自动切换 ---------- */
+    const cmTheme = EditorView.theme({
+      '&': { height: '100%', fontSize: '13px', backgroundColor: 'transparent' },
+      '.cm-content': { fontFamily: 'var(--sl-font-mono)', caretColor: 'var(--sl-color-text-accent)' },
+      '.cm-gutters': { backgroundColor: 'transparent', color: 'var(--sl-color-gray-4)', border: 'none' },
+      '&.cm-focused': { outline: 'none' },
+      '.cm-activeLine': { backgroundColor: 'color-mix(in oklab, currentColor 5%, transparent)' },
+      '.cm-activeLineGutter': { backgroundColor: 'transparent' },
+      '.cm-selectionBackground, &.cm-focused .cm-selectionBackground': { backgroundColor: 'color-mix(in oklab, var(--sl-color-text-accent) 25%, transparent) !important' },
+      '.cm-comment': { color: 'var(--sl-color-gray-4)' },
+      '.cm-string': { color: 'var(--sl-color-text-accent)' },
+      '.cm-number': { color: 'var(--sl-color-text-accent)' },
+      '.cm-keyword': { fontWeight: '600' },
+      '.cm-variableName': { color: 'var(--sl-color-text)' },
+      '.cm-bracket': { color: 'var(--sl-color-gray-3)' },
+    });
+
+    /* ---------- 校验 ---------- */
+    const WIDGETS = ['number','slider','color','select','toggle','image_path','text'];
+    const TYPES = ['rect','circle','circle_stroke','dashed_circle','triangle','polygon','line','text','image','path'];
+    const DYN_APIS = /(?<![.\w])(time_ms|now_ms|mouse_pos|mouse_velocity|mouse_acceleration|key_down|rand|rand_range|rand_int|parse_svg_path)\s*\(/g;
+
+    interface Check { level: 'ok' | 'warn' | 'err'; text: string }
+    function validate(src: string): Check[] {
+      const out: Check[] = [];
+      const has = (f: string) => new RegExp(`fn\\s+${f}\\s*\\(`).test(src);
+      for (const f of ['defaults', 'schema', 'build']) {
+        if (!has(f)) out.push({ level: 'err', text: t.needFn(f) });
+      }
+      if (!/^\/\/\s*Name:/.test(src.trimStart())) out.push({ level: 'warn', text: t.nameHint });
+
+      const dynDeclared = /fn\s+is_dynamic\s*\(\s*\)\s*\{\s*true/.test(src);
+      const dynCalled = [...src.matchAll(DYN_APIS)].length > 0;
+      if (dynCalled && !dynDeclared) out.push({ level: 'warn', text: t.dynApi });
+      if (dynCalled && has('is_dynamic') && !dynDeclared) out.push({ level: 'warn', text: t.staticDyn });
+      if (dynDeclared && !has('refresh_interval_ms')) out.push({ level: 'warn', text: t.refreshHint });
+
+      for (const m of src.matchAll(/widget:\s*"([\w]+)"/g)) {
+        if (!WIDGETS.includes(m[1])) out.push({ level: 'err', text: t.badWidget(m[1]) });
+      }
+      for (const m of src.matchAll(/type:\s*"([\w]+)"/g)) {
+        if (!TYPES.includes(m[1])) out.push({ level: 'err', text: t.badType(m[1]) });
+      }
+
+      // schema key ↔ defaults 默认值对齐（启发式：defaults() 体中的裸标识符键）。
+      const defaultsBody = src.match(/fn\s+defaults\s*\(\s*\)\s*\{([\s\S]*?)\n\}/)?.[1] ?? '';
+      const defKeys = new Set([...defaultsBody.matchAll(/(?:^|[,{]\s*)([a-zA-Z_]\w*)\s*:/gm)].map((m) => m[1]));
+      const schemaBody = src.match(/fn\s+schema\s*\(\s*\)\s*\{([\s\S]*?)\n\}/)?.[1] ?? '';
+      for (const m of schemaBody.matchAll(/key:\s*"([\w]+)"/g)) {
+        if (!defKeys.has(m[1])) out.push({ level: 'warn', text: t.schemaKey(m[1]) });
+      }
+      return out;
+    }
+
+    /* ---------- 模板 ---------- */
+    const templateSources: Record<string, { name: string; source: string }> = JSON.parse(
+      document.querySelector('script[type="application/json"][data-pg-templates]')!.textContent ?? '{}',
+    );
+
+    /* ---------- 装配 ---------- */
+    const initial = templateSources.cross;
+    let currentTemplateKey = 'cross';
+    const state = EditorState.create({
+      doc: initial.source,
+      extensions: [
+        basicSetup,
+        rhaiLang,
+        cmTheme,
+        EditorView.updateListener.of((u) => { if (u.docChanged) runChecks(); }),
+      ],
+    });
+    const host = root.querySelector<HTMLElement>('.pg-editor')!;
+    const view = new EditorView({ state, parent: host });
+
+    const checksEl = root.querySelector<HTMLElement>('.pg-checks')!;
+    const statusEl = root.querySelector<HTMLElement>('.pg-status')!;
+    const filenameEl = root.querySelector<HTMLInputElement>('.pg-filename')!;
+
+    const levelMark = {
+      ok: 'text-accent-600 dark:text-accent-400',
+      warn: 'text-gray-600 dark:text-gray-300',
+      err: 'text-red-600 dark:text-red-400',
+    };
+    const levelGlyph = { ok: '✓', warn: '!', err: '✕' };
+    function runChecks() {
+      const checks = validate(view.state.doc.toString());
+      const errs = checks.filter((c) => c.level === 'err').length;
+      checksEl.innerHTML = '';
+      if (checks.length === 0) {
+        checksEl.innerHTML = `<li class="text-sm ${levelMark.ok}"><span class="font-mono">${levelGlyph.ok}</span> ${t.allPass}</li>`;
+      } else {
+        for (const c of checks) {
+          const li = document.createElement('li');
+          li.className = `flex gap-2 text-sm ${levelMark[c.level]}`;
+          li.innerHTML = `<span class="font-mono shrink-0">${levelGlyph[c.level]}</span><span>${c.text}</span>`;
+          checksEl.appendChild(li);
+        }
+      }
+      statusEl.textContent = errs > 0 ? `${errs} ${t.err}` : t.allPass;
+    }
+    runChecks();
+
+    // 模板切换 / 重置。
+    root.querySelectorAll<HTMLButtonElement>('.pg-tpl').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const tpl = templateSources[btn.dataset.tpl!];
+        if (!tpl) return;
+        currentTemplateKey = btn.dataset.tpl!;
+        filenameEl.value = tpl.name;
+        view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: tpl.source } });
+      });
+    });
+    root.querySelector<HTMLButtonElement>('.pg-reset')!.addEventListener('click', () => {
+      const tpl = templateSources[currentTemplateKey];
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: tpl.source } });
+    });
+
+    // 下载 / 复制。
+    const currentText = () => view.state.doc.toString();
+    const safeName = () => (filenameEl.value.trim().replace(/[^\w-]/g, '_') || 'my_material');
+    root.querySelector<HTMLButtonElement>('.pg-download')!.addEventListener('click', () => {
+      const blob = new Blob([currentText()], { type: 'text/plain;charset=utf-8' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `${safeName()}.rhai`;
+      a.click();
+      URL.revokeObjectURL(a.href);
+    });
+    const copyBtn = root.querySelector<HTMLButtonElement>('.pg-copy')!;
+    copyBtn.addEventListener('click', async () => {
+      await navigator.clipboard.writeText(currentText());
+      const orig = copyBtn.textContent;
+      copyBtn.textContent = zh ? '已复制' : 'Copied';
+      setTimeout(() => { copyBtn.textContent = orig; }, 1500);
+    });
+  }
+</script>
+
+<script is:inline type="application/json" data-pg-templates set:html={JSON.stringify(templates)} />

--- a/docs/src/content/docs/playground.mdx
+++ b/docs/src/content/docs/playground.mdx
@@ -1,0 +1,20 @@
+---
+title: Playground
+description: Write and validate Peregrine custom material (.rhai) scripts in the browser, then download and drop them into your materials folder.
+tableOfContents: false
+# 独立工具页不参与指南翻页序列（与 download 页同策略）。
+prev: false
+next: false
+---
+
+import RhaiPlayground from '../../components/playground/RhaiPlayground.astro';
+
+A browser-side editor for Peregrine **custom materials** (`.rhai` scripts). Pick a template, tweak the code, watch the contract checks, then download the file and drop it into your materials folder — the app hot-reloads it automatically.
+
+<RhaiPlayground locale="en" />
+
+## Notes
+
+- The editor performs **static contract validation only** (required functions, widget & element-type whitelists, dynamic-API consistency). Real evaluation happens when Peregrine loads the file — invalid geometry fields surface in `peregrine.log`.
+- Previews are not rendered here; use the in-app preview (Settings → Layers) after installing — the preview and the overlay share the same evaluation pipeline (WYSIWYG).
+- See the [material scripting guide](./guide/material-scripting/) for the full API reference.

--- a/docs/src/content/docs/zh-cn/playground.mdx
+++ b/docs/src/content/docs/zh-cn/playground.mdx
@@ -1,0 +1,20 @@
+---
+title: 物料编辑器
+description: 在浏览器中编写并校验 Peregrine 自定义物料（.rhai 脚本），下载后放入物料文件夹即可热加载。
+tableOfContents: false
+# 独立工具页不参与指南翻页序列（与 download 页同策略）。
+prev: false
+next: false
+---
+
+import RhaiPlayground from '../../../components/playground/RhaiPlayground.astro';
+
+在浏览器里编写 Peregrine **自定义物料**（`.rhai` 脚本）：选一个模板起步，改代码，看契约校验结果，下载文件放进物料文件夹——应用会自动热加载，无需重启。
+
+<RhaiPlayground locale="zh-cn" />
+
+## 说明
+
+- 本编辑器只做**静态契约校验**（必需函数、widget 与图元类型白名单、动态 API 一致性）。真实求值发生在应用加载文件时——几何字段错误会在 `peregrine.log` 中体现。
+- 这里不渲染预览；安装后在应用内预览（设置 → 图层）——预览与 overlay 共用同一求值管线（WYSIWYG）。
+- 完整 API 参考见[物料脚本创作](./guide/material-scripting/)。


### PR DESCRIPTION
## 变更内容
- 文档站新增 `/playground` 页面（双语）：在线 .rhai 物料编辑器
- `RhaiPlayground.astro` 组件 + 默认主题 dark + 冒烟测试脚本
- 已在本地验证：`astro build` 41 页构建通过，`npm run verify` 全部 PASS

## 自检
- [x] 本地 docs 构建通过
- [x] verify-landing / verify-polish ALL PASS
- [x] rebase 至最新 main（无冲突）