### PR TITLE
fix(docs): 顶栏对齐 aukcraft.org 签名样式 + 页脚词标换用站点 logo

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -6,10 +6,13 @@
  * - 容器：mx-auto max-w-5xl px-6 居中（与 aukcraft.org 顶栏同一节奏），
  *   品牌左置、功能区右置（justify-between）；
  * - 品牌标识：图标 + 文字（SiteTitle，logo 配置见 astro.config.mjs）；
- * - 核心导航右置：Docs / Download / GitHub 平铺文本链接，统一 .link-line
- *   下划线（与落地页 Footer 链接同一基元：左→右生长、品牌蓝），active 态
- *   下划线常显；
- * - 语言切换：EN / 中文 平铺切换（斜杠分隔，无下拉），可点侧同样用 .link-line；
+ * - 核心导航右置：Docs / Download / Playground 平铺文本链接，统一 .link-line
+ *   下划线（与落地页 Footer 链接同一基元：左→右生长、品牌蓝），站内链接
+ *   uppercase + 宽字距、GitHub 外链用完整 github.com/… 文本（对齐 aukcraft.org
+ *   顶栏签名），active 态下划线常显；
+ * - 语言切换：EN / 中文 平铺切换（斜杠分隔，无下拉），当前语言为 muted 灰
+ *   （对齐 aukcraft.org），可点侧同样用 .link-line；品牌字标（SiteTitle）的
+ *   mono/ink 化在 starlight-polish.css 中覆写；
  * - 主题切换：图标按钮（sun/moon，lucide 线稿），点击在 dark/light 间翻转，
  *   写入 localStorage `starlight-theme` 与 <html data-theme>（与 Starlight
  *   ThemeProvider 协议一致）；
@@ -41,11 +44,17 @@ const shouldRenderSearch =
 // localeBase 内部处理了 llms.txt 等非 Starlight 渲染上下文（starlightRoute 未就绪会抛错）。
 const locale = localeBase(Astro);
 const prefix = locale ? `/${locale}` : '';
+// 与 aukcraft.org 顶栏同款：站内链接 uppercase + 宽字距（DOCS / DOWNLOAD …）；
+// 外链 GitHub 用完整 "github.com/…" 文本且不 uppercase（对齐 aukcraft 顶栏签名）。
 const navLinks = [
 	{ label: locale ? '文档' : 'Docs', href: `${prefix}/guide/intro`, external: false },
 	{ label: locale ? '下载' : 'Download', href: `${prefix}/download`, external: false },
 	{ label: locale ? '编辑器' : 'Playground', href: `${prefix}/playground`, external: false },
-	{ label: 'GitHub', href: 'https://github.com/eeymoo/peregrine', external: true },
+	{
+		label: 'github.com/eeymoo/peregrine',
+		href: 'https://github.com/eeymoo/peregrine',
+		external: true,
+	},
 ];
 // 当前页 active 态。路由判定最小化——pathname 去掉可选 .html 后缀与尾斜杠后前缀比较。
 // 注意 build.format: 'file' 下 Astro.url.pathname 形如 /guide/usage.html，必须先剥 .html。
@@ -86,6 +95,8 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 						<a
 							class:list={[
 								'header-nav-link link-line font-mono text-xs whitespace-nowrap',
+								// 站内链接与 aukcraft.org 同款：uppercase + 0.15em 宽字距；外链不 uppercase。
+								!l.external && 'uppercase tracking-[0.15em]',
 								'focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-200',
 								// active 态下划线常显：! 重要级任意值工具类（.link-line 基元在未分层
 								// 全局 CSS 中，普通 utilities 层规则压不过，需 ! 提升）。
@@ -101,19 +112,19 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 				})
 			}
 		</nav>
-		{/* 语言平铺切换：EN / 中文，当前语言高亮为 ink、另一语言为 .link-line 链接。 */}
+		{/* 语言平铺切换：EN / 中文，与 aukcraft.org 同款——当前语言为 muted 灰（不加粗），另一语言为 .link-line 链接。 */}
 		<span class="lang-toggle flex items-baseline gap-2 font-mono text-xs">
 			{
 				isZh ? (
 					<a class="link-line" href={enHref}>EN</a>
 				) : (
-					<span class="font-semibold text-gray-900 dark:text-gray-50" aria-current="true">EN</span>
+					<span class="text-gray-500 dark:text-gray-400" aria-current="true">EN</span>
 				)
 			}
-			<span class="text-gray-400 dark:text-gray-600" aria-hidden="true">/</span>
+			<span class="text-gray-400 dark:text-gray-500" aria-hidden="true">/</span>
 			{
 				isZh ? (
-					<span class="font-semibold text-gray-900 dark:text-gray-50" aria-current="true">中文</span>
+					<span class="text-gray-500 dark:text-gray-400" aria-current="true">中文</span>
 				) : (
 					<a class="link-line" href={zhHref}>中文</a>
 				)

--- a/docs/src/components/landing/Footer.astro
+++ b/docs/src/components/landing/Footer.astro
@@ -3,7 +3,8 @@
  * 落地页页脚（aukcraft 壳层，docs-aukcraft-shell）
  *
  * 参照 .agents/skills/aukcraft-site-design 的 Footer 资产改写：
- * - 词标 Peregrine + lucide Bird 图标（不引入 aukcraft PuffinMark 吉祥物）；
+ * - 词标 Peregrine + 站点 logo 图标（/logo.svg，与头栏 SiteTitle 同一标识，
+ *   不再用 lucide Bird、也不引入 aukcraft PuffinMark 吉祥物）；
  * - 站点导航（文档 / 下载 / GitHub ↗）用 .link-line 行内链接基元；
  * - 「开源」列：MIT 许可证 / 议题 / Releases 外链；
  * - 底行 hairline 分隔 + mono 微字版权行；
@@ -12,7 +13,6 @@
  *
  * 仅由双语 index.mdx 挂载（guide / download 页不挂，与 DotField 同范围）。
  */
-import { lucideIcon } from '../../lib/icons';
 import { localeBase } from '../../lib/locale';
 
 interface Props {
@@ -42,15 +42,14 @@ const ossNav = [
   { label: zh ? '议题' : 'Issues', href: 'https://github.com/eeymoo/peregrine/issues' },
   { label: 'Releases', href: 'https://github.com/eeymoo/peregrine/releases' },
 ];
-
-const birdIcon = lucideIcon('Bird');
 ---
 
 <footer class="lp-footer not-content mt-24 border-t border-(--sl-color-hairline)" data-pagefind-ignore>
   <div class="grid gap-12 py-16 md:grid-cols-3">
     <div>
       <p class="m-0 flex items-center gap-2 font-mono text-sm font-semibold tracking-tight text-gray-900 dark:text-gray-50">
-        <span class="inline-flex text-accent-600 dark:text-accent-400 [&_svg]:size-5" aria-hidden="true" set:html={birdIcon} />
+        {/* 站点 logo 图标（与头栏 SiteTitle 同一标识），尺寸对齐原 Bird 图标的 size-5。 */}
+        <img src="/logo.svg" alt="" aria-hidden="true" width="20" height="20" class="size-5" />
         Peregrine
       </p>
       <nav class="mt-6" aria-label="Site">

--- a/docs/src/styles/starlight-polish.css
+++ b/docs/src/styles/starlight-polish.css
@@ -233,6 +233,19 @@ site-search {
  * raised #14181D / 浅色端 #FFFFFF，见 global.css 语义映射）。若升级后 Select.astro
  * 引入圆角或阴影，需在此处补 ≤4px + 零阴影覆写。 */
 
+/* 品牌字标（SiteTitle.astro）：对齐 aukcraft.org 顶栏签名——mono text-sm +
+ * tracking-tight + ink 色（非品牌蓝）+ 常规字重，logo 收敛到 1.5rem（h-6）。
+ * 目标：@astrojs/starlight 0.41；内部 class：.header 内的 .site-title（SiteTitle.astro
+ * 内联声明 font-size: var(--sl-text-h4) / font-weight: 600 / text-accent / img 高度
+ * = --sl-nav-height - 2 * --sl-nav-pad-y，均在本文件未分层规则下被覆盖）。 */
+.header .site-title {
+  @apply font-mono text-sm tracking-tight font-normal text-gray-900 dark:text-gray-50;
+}
+
+.header .site-title img {
+  @apply h-6 w-auto;
+}
+
 /* -----------------------------------------------------------
  * 11. 落地页区块节奏（首页 MDX 中的 .lp-section / .lp-heading）
  *


### PR DESCRIPTION
## 改动说明

对齐 peregrine.aukcraft.org 与 aukcraft.org 的顶栏差异，并统一页脚品牌标识。

### 顶栏（Header.astro + starlight-polish.css）
- 站内导航链接 uppercase + 0.15em 宽字距（DOCS / DOWNLOAD / PLAYGROUND）
- GitHub 外链改完整 `github.com/eeymoo/peregrine` 文本、不 uppercase（aukcraft 顶栏签名）
- 语言切换当前语言改为 muted 灰（去加粗），分隔斜杠同步
- 品牌字标覆写为 mono text-sm tracking-tight + ink 色 + 常规字重，logo 24px

### 页脚（Footer.astro）
- 词标前的 lucide Bird 图标换为 `/logo.svg`（与头栏 SiteTitle 同一标识，20px）

### 有意保留的差异
- 主题切换按钮（本站双主题体系为设计锁定项；aukcraft 为单暗色主题）
- Starlight sticky bar 形态（文档站导航需要固定）

## 自查
- [x] `npm run build` 通过
- [x] `npm run verify` 全部 PASS
- [x] Playwright 实测 800/1024/1280px 顶栏零溢出、样式全部生效
- [x] 未引入手写 hex / 阴影 / >4px 圆角