### PR TITLE
fix(docs): 头栏与内容列同宽 + 全站对比度修复 + Skills 物料页

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,6 +21,7 @@ const sidebar = [
   { label: 'Docs', translations: { 'zh-CN': '文档' }, slug: 'guide/intro' },
   { label: 'Download', translations: { 'zh-CN': '下载' }, slug: 'download' },
   { label: 'Playground', translations: { 'zh-CN': '编辑器' }, slug: 'playground' },
+  { label: 'Skills', translations: { 'zh-CN': '技能物料' }, slug: 'skills' },
   {
     label: 'Guide',
     translations: { 'zh-CN': '指南' },

--- a/docs/scripts/verify-landing.mjs
+++ b/docs/scripts/verify-landing.mjs
@@ -290,12 +290,13 @@ for (const theme of ['dark', 'light']) {
       JSON.stringify(r.dlButtons),
     );
     check(
-      `${t} 顶栏导航 4 链接（Docs/Download/Playground/GitHub）`,
-      r.headerNav.length === 4 &&
+      `${t} 顶栏导航 5 链接（Docs/Download/Playground/Skills/GitHub）`,
+      r.headerNav.length === 5 &&
         r.headerNav[0].endsWith('/guide/intro') &&
         r.headerNav[1].endsWith('/download') &&
         r.headerNav[2].endsWith('/playground') &&
-        r.headerNav[3] === 'https://github.com/eeymoo/peregrine',
+        r.headerNav[3].endsWith('/skills') &&
+        r.headerNav[4] === 'https://github.com/eeymoo/peregrine',
       JSON.stringify(r.headerNav),
     );
     check(`${t} 顶栏保留`, r.topbar === true);
@@ -340,8 +341,10 @@ for (const theme of ['dark', 'light']) {
     // Header 导航区计算样式（aukcraft 平铺头栏 + .link-line 统一基元）
     const hnLinkColor = theme === 'dark' ? 'oklch(0.882 0.059 254.128)' : 'oklch(0.546 0.245 262.881)';
     check(
-      `${t} 头栏容器 max-w-5xl 居中`,
-      r.headerBox?.maxWidth === '1024px' && parseFloat(r.headerBox?.marginLeft) > 0,
+      // 宽度对齐修复：头栏内层与内容列同宽居中（--sl-content-width = 1080px），
+      // 不再是旧的 max-w-5xl(1024px) 居中盒。
+      `${t} 头栏容器与内容列同宽居中`,
+      r.headerBox?.maxWidth === '1080px' && parseFloat(r.headerBox?.marginLeft) > 0,
       JSON.stringify(r.headerBox),
     );
     check(

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -3,7 +3,9 @@
  * Starlight Header 覆写（本站点仅有的第二个组件覆写，第一个是 Hero）。
  *
  * aukcraft 平铺头栏（header-aukcraft-nav）：
- * - 容器：mx-auto max-w-5xl px-6 居中（与 aukcraft.org 顶栏同一节奏），
+ * - 容器：保持 Starlight 原生全宽内层（外层固定头栏自带 --sl-nav-pad-x 内边距，
+ *   下方保留的 Starlight 对齐网格会把品牌对齐到内容列左缘，与页面主体同宽；
+ *   不再叠加 aukcraft 的 max-w-5xl px-6 居中盒——那会使头栏与内容列错位）；
  *   品牌左置、功能区右置（justify-between）；
  * - 品牌标识：图标 + 文字（SiteTitle，logo 配置见 astro.config.mjs）；
  * - 核心导航右置：Docs / Download / Playground 平铺文本链接，统一 .link-line
@@ -50,6 +52,7 @@ const navLinks = [
 	{ label: locale ? '文档' : 'Docs', href: `${prefix}/guide/intro`, external: false },
 	{ label: locale ? '下载' : 'Download', href: `${prefix}/download`, external: false },
 	{ label: locale ? '编辑器' : 'Playground', href: `${prefix}/playground`, external: false },
+	{ label: locale ? '技能' : 'Skills', href: `${prefix}/skills`, external: false },
 	{
 		label: 'github.com/eeymoo/peregrine',
 		href: 'https://github.com/eeymoo/peregrine',
@@ -79,7 +82,7 @@ const moonIcon = lucideIcon('Moon');
 const themeLabel = locale ? '切换主题' : 'Toggle theme';
 ---
 
-<div class="header mx-auto! w-full max-w-5xl! px-6">
+<div class="header w-full">
 	<div class="title-wrapper sl-flex">
 		<SiteTitle />
 	</div>
@@ -118,13 +121,13 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 				isZh ? (
 					<a class="link-line" href={enHref}>EN</a>
 				) : (
-					<span class="text-gray-500 dark:text-gray-400" aria-current="true">EN</span>
+					<span class="text-gray-600 dark:text-gray-400" aria-current="true">EN</span>
 				)
 			}
 			<span class="text-gray-400 dark:text-gray-500" aria-hidden="true">/</span>
 			{
 				isZh ? (
-					<span class="text-gray-500 dark:text-gray-400" aria-current="true">中文</span>
+					<span class="text-gray-600 dark:text-gray-400" aria-current="true">中文</span>
 				) : (
 					<a class="link-line" href={zhHref}>中文</a>
 				)
@@ -199,6 +202,19 @@ const themeLabel = locale ? '切换主题' : 'Toggle theme';
 		/* 搜索图标按钮贴右侧功能区（中间 1fr 列仅作留白）。 */
 		.search-slot {
 			justify-content: flex-end;
+		}
+
+		/* 头栏与内容列同宽（宽度对齐修复）：无侧栏页面（首页 / download 等单栏页）
+		 * 下方内容列是 mx-auto + max-width: var(--sl-content-width) 的居中盒，
+		 * 头栏内层用同一变量居中限宽即可与正文左缘对齐（外层固定头栏自带
+		 * --sl-nav-pad-x 内边距，居中盒宽度不小于剩余空间时自动退化为全宽）。
+		 * 侧栏页（guide 等）不套用——内容列被 sidebar + toc 推移，头栏保持
+		 * Starlight 原生全宽形态。 */
+		@media (min-width: 50rem) {
+			:global(html:not([data-has-sidebar])) .header {
+				margin-inline: auto;
+				max-width: var(--sl-content-width);
+			}
 		}
 
 		@media (min-width: 50rem) {

--- a/docs/src/components/landing/DownloadTable.astro
+++ b/docs/src/components/landing/DownloadTable.astro
@@ -187,7 +187,7 @@ const PILL =
                         '—'
                       )}
                     </td>
-                    <td class="dt-note text-[0.8125rem] text-gray-500 dark:text-gray-400">{labels.note}</td>
+                    <td class="dt-note text-[0.8125rem] text-gray-600 dark:text-gray-400">{labels.note}</td>
                   </tr>
                 );
               })}

--- a/docs/src/components/landing/SkillsGrid.astro
+++ b/docs/src/components/landing/SkillsGrid.astro
@@ -1,0 +1,69 @@
+---
+/**
+ * Skills 开发物料列表（对齐 aukcraft.org/skills 的物料页语法，D10）。
+ *
+ * - 数据：构建期读取仓库 .agents/skills 下每个 skill 的 SKILL.md frontmatter（loadSkills）；
+ * - 布局家族：hairline 行列表（行间 1px 发丝线分隔，编号 01…NN + 名称 + 描述 +
+ *   源文件路径），与 FeatureGrid 的 gap-px 网格、正文 prose 均不重复；
+ * - 文案：描述即 SKILL.md 原文（中文），双语页共用同一数据源，仅标签翻译。
+ */
+import { loadSkills, skillSourceUrl } from '../../lib/skills';
+
+interface Props {
+  /** locale URL base（root=en 无前缀）。 */
+  locale?: string;
+  /** 区块标签（如 "Skills" / "技能物料"）。 */
+  label: string;
+  /** 计数后缀（如 "skills" / "个"）。 */
+  unit: string;
+  /** 源文件链接文案。 */
+  sourceLabel: string;
+}
+
+const { locale, label, unit, sourceLabel } = Astro.props;
+const skills = loadSkills();
+const zh = locale === 'zh-cn';
+---
+
+<section class="not-content" aria-label={label}>
+  <div class="flex items-baseline justify-between gap-4 border-b border-(--sl-color-hairline) pb-3">
+    <p class="micro m-0 font-mono text-xs uppercase tracking-[0.15em] text-gray-600 dark:text-gray-400">
+      {label}
+    </p>
+    <p class="m-0 font-mono text-xs text-gray-600 dark:text-gray-400">
+      {skills.length} {unit}
+    </p>
+  </div>
+  <ol class="m-0 list-none p-0">
+    {
+      skills.map((skill, i) => (
+        <li class="grid gap-x-6 gap-y-2 border-b border-(--sl-color-hairline) py-5 md:grid-cols-[10rem_minmax(0,1fr)]">
+          <div class="flex items-baseline gap-3 md:block">
+            <span class="font-mono text-xs text-gray-400 dark:text-gray-600">
+              {String(i + 1).padStart(2, '0')}
+            </span>
+            <a
+              class="link-line font-mono text-sm font-semibold tracking-tight text-gray-900 dark:text-gray-50"
+              href={skillSourceUrl(skill.name)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {skill.name}
+            </a>
+          </div>
+          <div>
+            <p class="m-0 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+              {skill.description || (zh ? '（无描述）' : '(no description)')}
+            </p>
+            <p class="m-0 mt-2 font-mono text-xs text-gray-500 dark:text-gray-500">
+              .agents/skills/{skill.name}/SKILL.md ·{' '}
+              <a class="link-line" href={skillSourceUrl(skill.name)} target="_blank" rel="noopener noreferrer">
+                {sourceLabel}
+              </a>
+            </p>
+          </div>
+        </li>
+      ))
+    }
+  </ol>
+</section>

--- a/docs/src/components/playground/RhaiPlayground.astro
+++ b/docs/src/components/playground/RhaiPlayground.astro
@@ -149,10 +149,10 @@ fn build(params, screen) {
 >
   <div class="bg-gray-50 p-4 sm:p-5 dark:bg-gray-950">
     <div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
-      <span class="font-mono text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">
+      <span class="font-mono text-xs uppercase tracking-widest text-gray-600 dark:text-gray-400">
         {i18n.editorLabel}
       </span>
-      <span class="pg-status font-mono text-xs text-gray-400 dark:text-gray-500"></span>
+      <span class="pg-status font-mono text-xs text-gray-600 dark:text-gray-500"></span>
       <span class="ml-auto flex items-center gap-2">
         <label class="sr-only" for="pg-filename">{i18n.filename}</label>
         <input
@@ -161,18 +161,18 @@ fn build(params, screen) {
           value={templates.cross.name}
           spellcheck="false"
         />
-        <span class="font-mono text-xs text-gray-400 dark:text-gray-500">.rhai</span>
+        <span class="font-mono text-xs text-gray-600 dark:text-gray-500">.rhai</span>
       </span>
     </div>
     <div class="pg-editor min-h-80 overflow-hidden rounded-sm border border-(--sl-color-hairline) bg-gray-100 dark:bg-gray-900"></div>
     <div class="mt-3 flex flex-wrap items-center gap-2">
-      <span class="font-mono text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">
+      <span class="font-mono text-xs uppercase tracking-widest text-gray-600 dark:text-gray-400">
         {i18n.templates}
       </span>
       {
         Object.entries(templates).map(([key, tpl]) => (
           <button
-            class="pg-tpl font-mono text-xs text-ink motion-safe:transition-colors hover:text-accent-600 dark:hover:text-accent-400"
+            class="pg-tpl bg-transparent font-mono text-xs text-gray-700 motion-safe:transition-colors hover:text-accent-600 dark:text-gray-300 dark:hover:text-accent-400"
             data-tpl={key}
             type="button"
           >
@@ -180,7 +180,7 @@ fn build(params, screen) {
           </button>
         ))
       }
-      <button class="pg-reset ml-auto font-mono text-xs text-gray-500 hover:text-accent-600 dark:text-gray-400 dark:hover:text-accent-400" type="button">
+      <button class="pg-reset ml-auto bg-transparent font-mono text-xs text-gray-600 hover:text-accent-600 dark:text-gray-400 dark:hover:text-accent-400" type="button">
         {i18n.reset}
       </button>
     </div>
@@ -188,26 +188,26 @@ fn build(params, screen) {
 
   <div class="bg-gray-50 flex flex-col gap-4 p-4 sm:p-5 dark:bg-gray-950">
     <div>
-      <h3 class="mb-2 font-mono text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">
+      <h3 class="mb-2 font-mono text-xs uppercase tracking-widest text-gray-600 dark:text-gray-400">
         {i18n.validation}
       </h3>
       <ul class="pg-checks space-y-1.5 text-sm"></ul>
     </div>
     <div>
-      <h3 class="mb-2 font-mono text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">
+      <h3 class="mb-2 font-mono text-xs uppercase tracking-widest text-gray-600 dark:text-gray-400">
         {i18n.install}
       </h3>
       <p class="text-sm leading-relaxed text-gray-600 dark:text-gray-300">{i18n.installBody}</p>
     </div>
     <div class="mt-auto flex flex-wrap gap-2">
       <button
-        class="pg-download flight font-mono text-xs uppercase tracking-widest text-accent"
+        class="pg-download flight bg-transparent font-mono text-xs uppercase tracking-widest text-accent"
         type="button"
       >
         {i18n.download}
       </button>
       <button
-        class="pg-copy link-line font-mono text-xs uppercase tracking-widest"
+        class="pg-copy link-line bg-transparent font-mono text-xs uppercase tracking-widest"
         type="button"
       >
         {i18n.copy}
@@ -219,8 +219,9 @@ fn build(params, screen) {
 <script>
   import { EditorState } from '@codemirror/state';
   import { EditorView } from '@codemirror/view';
-  import { StreamLanguage } from '@codemirror/language';
+  import { HighlightStyle, StreamLanguage, syntaxHighlighting } from '@codemirror/language';
   import { basicSetup } from 'codemirror';
+  import { tags as cmTags } from '@lezer/highlight';
 
   type Lang = 'en' | 'zh-cn';
   const root = document.querySelector<HTMLElement>('.pg-root');
@@ -264,8 +265,7 @@ fn build(params, screen) {
     });
 
     /* ---------- 主题：引用 @theme tokens，随明暗自动切换 ---------- */
-    const cmTheme = EditorView.theme({
-      '&': { height: '100%', fontSize: '13px', backgroundColor: 'transparent' },
+    const cmTheme = EditorView.theme({      '&': { height: '100%', fontSize: '13px', backgroundColor: 'transparent' },
       '.cm-content': { fontFamily: 'var(--sl-font-mono)', caretColor: 'var(--sl-color-text-accent)' },
       '.cm-gutters': { backgroundColor: 'transparent', color: 'var(--sl-color-gray-4)', border: 'none' },
       '&.cm-focused': { outline: 'none' },
@@ -279,6 +279,22 @@ fn build(params, screen) {
       '.cm-variableName': { color: 'var(--sl-color-text)' },
       '.cm-bracket': { color: 'var(--sl-color-gray-3)' },
     });
+
+    /* ---------- 语法高亮配色：覆盖 basicSetup 内置 defaultHighlightStyle ----------
+     * 该内置样式是硬编码的浅色调色板（紫关键字 / 暗红字符串 / 墨绿数字），
+     * 在暗色编辑器底上对比度仅 1.8–2.7:1 不可读。此处用同一批 --sl-color-* 语义
+     * 变量定义 HighlightStyle，后注册的样式优先生效，明暗随 <html data-theme> 翻转。 */
+    const cmHighlight = HighlightStyle.define([
+      { tag: cmTags.comment, color: 'var(--sl-color-gray-3)' },
+      { tag: cmTags.string, color: 'var(--sl-color-text-accent)' },
+      { tag: cmTags.number, color: 'var(--sl-color-text-accent)' },
+      { tag: cmTags.bool, color: 'var(--sl-color-text-accent)' },
+      { tag: cmTags.keyword, color: 'var(--sl-color-text-accent)', fontWeight: '600' },
+      { tag: cmTags.variableName, color: 'var(--sl-color-text)' },
+      { tag: cmTags.bracket, color: 'var(--sl-color-gray-3)' },
+      { tag: cmTags.operator, color: 'var(--sl-color-gray-2)' },
+      { tag: cmTags.punctuation, color: 'var(--sl-color-gray-3)' },
+    ]);
 
     /* ---------- 校验 ---------- */
     const WIDGETS = ['number','slider','color','select','toggle','image_path','text'];
@@ -329,6 +345,7 @@ fn build(params, screen) {
       doc: initial.source,
       extensions: [
         basicSetup,
+        syntaxHighlighting(cmHighlight),
         rhaiLang,
         cmTheme,
         EditorView.updateListener.of((u) => { if (u.docChanged) runChecks(); }),

--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -1,0 +1,21 @@
+---
+title: Skills
+description: Reusable agent skills — engineering practice distilled from daily Peregrine development, ready to drop into any agent session.
+tableOfContents: false
+# 独立物料页不参与指南翻页序列（与 download / playground 页同策略）。
+prev: false
+next: false
+---
+
+import SkillsGrid from '../../components/landing/SkillsGrid.astro';
+
+A set of reusable agent skills — release workflow, bugfix discipline, spec-driven development, i18n audits and more — distilled from daily work on Peregrine, ready to drop into any AI coding session.
+
+Each skill lives in [`.agents/skills/<name>/SKILL.md`](https://github.com/Eeymoo/peregrine/tree/main/.agents/skills) in the repository. Agents loaded in this repo pick them up automatically; humans can read them as concise engineering checklists.
+
+<SkillsGrid
+  locale="en"
+  label="Skills"
+  unit="skills"
+  sourceLabel="View source"
+/>

--- a/docs/src/content/docs/zh-cn/skills.mdx
+++ b/docs/src/content/docs/zh-cn/skills.mdx
@@ -1,0 +1,21 @@
+---
+title: 技能物料
+description: 可复用的 agent skills——从 Peregrine 日常开发中提炼的工程经验，随取随用。
+tableOfContents: false
+# 独立物料页不参与指南翻页序列（与 download / playground 页同策略）。
+prev: false
+next: false
+---
+
+import SkillsGrid from '../../../components/landing/SkillsGrid.astro';
+
+一套可复用的 agent skills——发布流程、bug 修复纪律、规格驱动开发、i18n 审查等，从 Peregrine 的日常开发中提炼而来，可直接装入任意 AI 编码会话。
+
+每个 skill 位于仓库的 [`.agents/skills/<name>/SKILL.md`](https://github.com/Eeymoo/peregrine/tree/main/.agents/skills)。在本仓库中加载的 agent 会自动识别它们；人类读者也可以把它们当作精炼的工程检查清单。
+
+<SkillsGrid
+  locale="zh-cn"
+  label="技能物料"
+  unit="个"
+  sourceLabel="查看源文件"
+/>

--- a/docs/src/lib/skills.ts
+++ b/docs/src/lib/skills.ts
@@ -1,0 +1,46 @@
+/**
+ * Skills 开发物料加载器（构建期执行，纯 fs 读取，无运行时开销）。
+ *
+ * 数据源：仓库根 .agents/skills/<name>/SKILL.md 的 YAML frontmatter
+ * （name + description），与 aukcraft.org/skills 的物料同一体裁——
+ * agent skills 即「从日常工作中提炼的工程经验，随取随用」。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** 单条 skill 物料：目录名 + frontmatter 描述。 */
+export interface SkillEntry {
+	/** skill 目录名（即 skill id，如 release / bugfix）。 */
+	name: string;
+	/** frontmatter description（单行中文描述）。 */
+	description: string;
+}
+
+/**
+ * 读取全部 skills 并按目录名排序。
+ * 在 Astro 组件 frontmatter（构建期）调用；目录缺失时返回空列表以容错。
+ * 路径解析基于 process.cwd()（dev / build 时均为 docs/ 目录）——不能用
+ * import.meta.url：静态构建会把组件打进 dist chunk，相对其定位会指错位置。
+ */
+export function loadSkills(): SkillEntry[] {
+	const skillsDir = path.resolve(process.cwd(), '../.agents/skills');
+	if (!fs.existsSync(skillsDir)) return [];
+	return fs
+		.readdirSync(skillsDir)
+		.filter((d) => fs.statSync(path.join(skillsDir, d)).isDirectory())
+		.sort()
+		.map((name) => {
+			const file = path.join(skillsDir, name, 'SKILL.md');
+			if (!fs.existsSync(file)) return { name, description: '' };
+			const raw = fs.readFileSync(file, 'utf8');
+			const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? '';
+			const description =
+				fm.match(/^description:\s*(.+)$/m)?.[1]?.trim().replace(/^["']|["']$/g, '') ?? '';
+			return { name, description };
+		});
+}
+
+/** GitHub 上 SKILL.md 的源文件链接（供页面「查看源文件」入口）。 */
+export function skillSourceUrl(name: string): string {
+	return `https://github.com/Eeymoo/peregrine/blob/main/.agents/skills/${name}/SKILL.md`;
+}

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -52,6 +52,15 @@
   --sl-color-hairline: var(--color-hairline-light);
   --sl-color-hairline-light: var(--color-hairline-light);
   --sl-color-hairline-shade: var(--color-hairline-light);
+  /* 浅色 ink：--sl-color-white 承载 Starlight 正文/标题文字色，必须在浅色分支
+   * 重新指向深色 ink（gray-900）。否则上方 :root 的 gray-50（未分层）会压过
+   * Starlight @layer starlight.base 的浅色翻转，浅色主题文字近白不可见。 */
+  --sl-color-white: var(--color-gray-900);
+  /* 次要文字对比度校准：兼容包把浅色 --sl-color-gray-3 映射为 gray-500，
+   * 在浅底 #F5F7F9 上仅 3.37:1（侧栏组标签 / 移动端 TOC / CodeMirror 注释等
+   * 大量次要文字低于 WCAG AA）。提升到 gray-600（≈4.9:1）；暗色端
+   * gray-400（≈7:1）无需调整。 */
+  --sl-color-gray-3: var(--color-gray-600);
   /* 零阴影（D4）：浅色主题同样无阴影 */
   --sl-shadow-sm: none;
   --sl-shadow-md: none;

--- a/docs/src/styles/starlight-polish.css
+++ b/docs/src/styles/starlight-polish.css
@@ -25,8 +25,13 @@
  * margin/max-width 节奏声明，见该节注释）。
  */
 
-/* 使本文件的 @apply 可解析 Tailwind 工具类（v4 独立 CSS 文件需显式 @reference 主题）。 */
+/* 使本文件的 @apply 可解析 Tailwind 工具类（v4 独立 CSS 文件需显式 @reference 主题）。
+ * 必须同时 reference 兼容包：dark: 变体的桥接定义（[data-theme=dark]）在
+ * @astrojs/starlight-tailwind/tailwind.css 的 @custom-variant 中——只 reference
+ * 'tailwindcss' 会让 dark: 退化为 prefers-color-scheme 媒体查询，导致
+ * 「OS 浅色偏好 + 手动切暗色」时 @apply 的 dark: 工具类不生效（文字隐形）。 */
 @reference 'tailwindcss';
+@reference '../../node_modules/@astrojs/starlight-tailwind/tailwind.css';
 
 /* -----------------------------------------------------------
  * 1. 正文排版节奏


### PR DESCRIPTION
## 改动说明

### 1. 头栏宽度与内容列对齐
- 移除头栏内层叠加的 `max-w-5xl px-6` 居中盒（与 Starlight 原生对齐网格冲突导致错位）
- 无侧栏页面（首页等）改用 `--sl-content-width` 居中限宽，与正文 `sl-container` 左右缘完全对齐（1440px 下 180=180 实测）

### 2. 全站颜色/背景可视性修复（Playwright WCAG 审计驱动，11 页 × 双主题）
- **浅色主题隐形文字**：`--sl-color-white` 缺浅色分支定义，浅色下正文/标题为近白灰落在浅底上；补 `gray-900` ink
- **主题切换脱钩**：polish css 中 `@apply dark:` 编译为 `prefers-color-scheme` 而非 `[data-theme=dark]`，OS 浅色偏好 + 手动切暗色时文字隐形；补 `@reference` 兼容包
- 浅色 `--sl-color-gray-3` gray-500 → gray-600（侧栏组标签/TOC/CM 注释 3.37→4.9:1）
- Playground：自定义 HighlightStyle 替换 CodeMirror 内置浅色调色板（暗色下 1.8–2.7:1）；按钮去 UA 底色；浅色标签提深
- 语言切换当前语言 muted 灰过 AA

### 3. Skills 开发物料页（对齐 aukcraft.org/skills）
- 新增 `/skills` + `/zh-cn/skills`：构建期读取仓库 `.agents/skills/*/SKILL.md`，hairline 行列表呈现 13 条物料
- 头栏导航 + 侧栏加入 Skills 入口；verify-landing 断言同步更新

## 自查
- [x] `npm run build` 43 页通过
- [x] `npm run verify` ALL PASS
- [x] Playwright 实测对齐 / skills 双语各 13 行 / 对比度审计通过
- [x] 未引入手写 hex / 阴影 / >4px 圆角