### PR TITLE
fix(docs): Skills 页只展示官方 skills/ 物料（material-creation）

### DIFF
--- a/docs/src/components/landing/SkillsGrid.astro
+++ b/docs/src/components/landing/SkillsGrid.astro
@@ -1,13 +1,13 @@
 ---
 /**
- * Skills 开发物料列表（对齐 aukcraft.org/skills 的物料页语法，D10）。
+ * 官方 Skills 物料列表（对齐 aukcraft.org/skills 的物料页语法，D10）。
  *
- * - 数据：构建期读取仓库 .agents/skills 下每个 skill 的 SKILL.md frontmatter（loadSkills）；
- * - 布局家族：hairline 行列表（行间 1px 发丝线分隔，编号 01…NN + 名称 + 描述 +
- *   源文件路径），与 FeatureGrid 的 gap-px 网格、正文 prose 均不重复；
- * - 文案：描述即 SKILL.md 原文（中文），双语页共用同一数据源，仅标签翻译。
+ * - 数据：构建期读取仓库 skills/<name>/SKILL.md frontmatter（loadSkills），
+ *   仅官方发布物料（skills.sh 生态布局）；
+ * - 布局家族：hairline 行列表（编号 + 名称 + 描述 + 安装命令 + 源文件路径）；
+ * - 安装命令与 skills/README.md 的「方式一」保持一字不差。
  */
-import { loadSkills, skillSourceUrl } from '../../lib/skills';
+import { loadSkills, skillInstallCmd, skillSourceUrl } from '../../lib/skills';
 
 interface Props {
   /** locale URL base（root=en 无前缀）。 */
@@ -16,11 +16,13 @@ interface Props {
   label: string;
   /** 计数后缀（如 "skills" / "个"）。 */
   unit: string;
+  /** 安装区块标签。 */
+  installLabel: string;
   /** 源文件链接文案。 */
   sourceLabel: string;
 }
 
-const { locale, label, unit, sourceLabel } = Astro.props;
+const { locale, label, unit, installLabel, sourceLabel } = Astro.props;
 const skills = loadSkills();
 const zh = locale === 'zh-cn';
 ---
@@ -37,7 +39,7 @@ const zh = locale === 'zh-cn';
   <ol class="m-0 list-none p-0">
     {
       skills.map((skill, i) => (
-        <li class="grid gap-x-6 gap-y-2 border-b border-(--sl-color-hairline) py-5 md:grid-cols-[10rem_minmax(0,1fr)]">
+        <li class="grid gap-x-6 gap-y-3 border-b border-(--sl-color-hairline) py-6 md:grid-cols-[10rem_minmax(0,1fr)]">
           <div class="flex items-baseline gap-3 md:block">
             <span class="font-mono text-xs text-gray-400 dark:text-gray-600">
               {String(i + 1).padStart(2, '0')}
@@ -55,8 +57,16 @@ const zh = locale === 'zh-cn';
             <p class="m-0 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
               {skill.description || (zh ? '（无描述）' : '(no description)')}
             </p>
+            <div class="mt-3">
+              <p class="m-0 font-mono text-[0.6875rem] uppercase tracking-[0.15em] text-gray-500 dark:text-gray-500">
+                {installLabel}
+              </p>
+              <code class="mt-1.5 block overflow-x-auto rounded border border-(--sl-color-hairline) bg-(--sl-color-bg-inline-code) px-3 py-2 font-mono text-xs text-gray-800 dark:text-gray-200">
+                {skillInstallCmd(skill.name)}
+              </code>
+            </div>
             <p class="m-0 mt-2 font-mono text-xs text-gray-500 dark:text-gray-500">
-              .agents/skills/{skill.name}/SKILL.md ·{' '}
+              skills/{skill.name}/SKILL.md ·{' '}
               <a class="link-line" href={skillSourceUrl(skill.name)} target="_blank" rel="noopener noreferrer">
                 {sourceLabel}
               </a>

--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Skills
-description: Reusable agent skills — engineering practice distilled from daily Peregrine development, ready to drop into any agent session.
+description: Official Peregrine agent skills — installable via the skills CLI, ready to drop into any AI coding session.
 tableOfContents: false
 # 独立物料页不参与指南翻页序列（与 download / playground 页同策略）。
 prev: false
@@ -9,13 +9,14 @@ next: false
 
 import SkillsGrid from '../../components/landing/SkillsGrid.astro';
 
-A set of reusable agent skills — release workflow, bugfix discipline, spec-driven development, i18n audits and more — distilled from daily work on Peregrine, ready to drop into any AI coding session.
+Official Peregrine skills for AI coding agents — a complete authoring manual distilled into drop-in skill files. After installing, just tell your agent what anchor you want (e.g. "make me a breathing ring crosshair") and it produces a ready-to-load `.rhai` material.
 
-Each skill lives in [`.agents/skills/<name>/SKILL.md`](https://github.com/Eeymoo/peregrine/tree/main/.agents/skills) in the repository. Agents loaded in this repo pick them up automatically; humans can read them as concise engineering checklists.
+Install everything at once with `npx skills add eeymoo/peregrine`, or pick a single skill below. See [skills/README.md](https://github.com/Eeymoo/peregrine/blob/main/skills/README.md) for all install methods (CLI, one-liner, manual).
 
 <SkillsGrid
   locale="en"
   label="Skills"
   unit="skills"
+  installLabel="Install"
   sourceLabel="View source"
 />

--- a/docs/src/content/docs/zh-cn/skills.mdx
+++ b/docs/src/content/docs/zh-cn/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: 技能物料
-description: 可复用的 agent skills——从 Peregrine 日常开发中提炼的工程经验，随取随用。
+description: Peregrine 官方 agent skills——经 skills CLI 安装，可直接装入任意 AI 编码会话。
 tableOfContents: false
 # 独立物料页不参与指南翻页序列（与 download / playground 页同策略）。
 prev: false
@@ -9,13 +9,14 @@ next: false
 
 import SkillsGrid from '../../../components/landing/SkillsGrid.astro';
 
-一套可复用的 agent skills——发布流程、bug 修复纪律、规格驱动开发、i18n 审查等，从 Peregrine 的日常开发中提炼而来，可直接装入任意 AI 编码会话。
+Peregrine 官方 agent skills——把完整的物料创作手册提炼成即装即用的技能文件。安装后对任意代理说出你想要的锚点（如「帮我做一个呼吸圆环准心」），即可产出可直接加载的 `.rhai` 物料。
 
-每个 skill 位于仓库的 [`.agents/skills/<name>/SKILL.md`](https://github.com/Eeymoo/peregrine/tree/main/.agents/skills)。在本仓库中加载的 agent 会自动识别它们；人类读者也可以把它们当作精炼的工程检查清单。
+一条命令安装全部技能：`npx skills add eeymoo/peregrine`，也可以从下方单独安装。全部安装方式（CLI / 一句话 / 手动）见 [skills/README.md](https://github.com/Eeymoo/peregrine/blob/main/skills/README.md)。
 
 <SkillsGrid
   locale="zh-cn"
   label="技能物料"
   unit="个"
+  installLabel="安装"
   sourceLabel="查看源文件"
 />

--- a/docs/src/lib/skills.ts
+++ b/docs/src/lib/skills.ts
@@ -1,29 +1,33 @@
 /**
- * Skills 开发物料加载器（构建期执行，纯 fs 读取，无运行时开销）。
+ * 官方 Skills 物料加载器（构建期执行，纯 fs 读取，无运行时开销）。
  *
- * 数据源：仓库根 .agents/skills/<name>/SKILL.md 的 YAML frontmatter
- * （name + description），与 aukcraft.org/skills 的物料同一体裁——
- * agent skills 即「从日常工作中提炼的工程经验，随取随用」。
+ * 数据源：仓库根 skills/<name>/SKILL.md 的 YAML frontmatter（name + description）。
+ * 该目录是面向外部发布 的
+ * skills.sh 开放技能生态布局——只展示这些官方物料，仓库内部 .agents/skills
+ * 工作流技能不在站点外显。
  */
 import fs from 'node:fs';
 import path from 'node:path';
 
-/** 单条 skill 物料：目录名 + frontmatter 描述。 */
+/** 单条官方 skill 物料。 */
 export interface SkillEntry {
-	/** skill 目录名（即 skill id，如 release / bugfix）。 */
+	/** skill 目录名（即 skill id，如 material-creation）。 */
 	name: string;
-	/** frontmatter description（单行中文描述）。 */
+	/** frontmatter description（触发时机描述，中文）。 */
 	description: string;
 }
 
+/** 仓库标识（skills CLI 的安装源）。 */
+export const SKILLS_REPO = 'eeymoo/peregrine';
+
 /**
- * 读取全部 skills 并按目录名排序。
+ * 读取 skills/ 下全部官方 skill 并按目录名排序。
  * 在 Astro 组件 frontmatter（构建期）调用；目录缺失时返回空列表以容错。
  * 路径解析基于 process.cwd()（dev / build 时均为 docs/ 目录）——不能用
  * import.meta.url：静态构建会把组件打进 dist chunk，相对其定位会指错位置。
  */
 export function loadSkills(): SkillEntry[] {
-	const skillsDir = path.resolve(process.cwd(), '../.agents/skills');
+	const skillsDir = path.resolve(process.cwd(), '../skills');
 	if (!fs.existsSync(skillsDir)) return [];
 	return fs
 		.readdirSync(skillsDir)
@@ -40,7 +44,12 @@ export function loadSkills(): SkillEntry[] {
 		});
 }
 
-/** GitHub 上 SKILL.md 的源文件链接（供页面「查看源文件」入口）。 */
+/** GitHub 上 SKILL.md 的源文件链接。 */
 export function skillSourceUrl(name: string): string {
-	return `https://github.com/Eeymoo/peregrine/blob/main/.agents/skills/${name}/SKILL.md`;
+	return `https://github.com/Eeymoo/peregrine/blob/main/skills/${name}/SKILL.md`;
+}
+
+/** 单个 skill 的 skills CLI 安装命令（指向仓库内目录，README 方式一）。 */
+export function skillInstallCmd(name: string): string {
+	return `npx skills add https://github.com/eeymoo/peregrine/tree/main/skills/${name}`;
 }


### PR DESCRIPTION
## 改动说明

按反馈收敛 Skills 物料页范围：

- 数据源从内部 `.agents/skills`（13 条工作流技能，不应外显）切换为仓库根 `skills/` 官方发布目录（skills.sh 生态布局），当前仅 `material-creation` 一条
- 每条物料补安装命令块（`npx skills add <repo 内目录>`，与 `skills/README.md` 方式一一字不差）+ 源文件路径链接
- 双语页文案改为官方物料口吻（一条命令装全部 / 单装 / README 全部安装方式）

## 自查
- [x] `npm run build` 通过（skills 页 1 skill，无 `.agents/skills` 泄露）
- [x] `npm run verify` ALL PASS